### PR TITLE
Make candidate calculation scripts enter numbers as strings into the candidate JSON files

### DIFF
--- a/src/scripts/candidate_calculation_industry.py
+++ b/src/scripts/candidate_calculation_industry.py
@@ -86,7 +86,7 @@ def to_json(dataframe, directory=DIRECTORY):
             file.setdefault("by industry", [{}])
             value = dataframe.loc[file[JSON_KEY]]
             file["by industry"][0] = {
-                f"industry {i}": array[1].tolist()
+                f"industry {i}": [str(x) for x in array[1]]
                 for i, array in enumerate(value.iterrows(), start=1)
             }
             with open(path, "w") as f:

--- a/src/scripts/candidate_calculation_industry.py
+++ b/src/scripts/candidate_calculation_industry.py
@@ -89,9 +89,9 @@ def to_json(dataframe, directory=DIRECTORY):
                 f"industry {i}": array[1].tolist()
                 for i, array in enumerate(value.iterrows(), start=1)
             }
-        with open(path, "w") as f:
-            json.dump(file, f, indent=2)
-            f.write("\n")
+            with open(path, "w") as f:
+                json.dump(file, f, indent=2)
+                f.write("\n")
 
 
 if __name__ == "__main__":

--- a/src/scripts/shared_calculations.py
+++ b/src/scripts/shared_calculations.py
@@ -68,13 +68,6 @@ def summed_contributions(paths, types, column):
     return pd.Series(df[column], index=df.index).groupby(CSV_KEY).sum()
 
 
-def to_py_type(value):
-    """Convert numpy types to normal types."""
-    if type(value).__module__ == "numpy" and hasattr(value, "item"):
-        return value.item()
-    return value
-
-
 def to_raised_json(series, field, directory=DIRECTORY):
     """
     Update Candidate JSON files in directory from series and field.
@@ -102,7 +95,7 @@ def to_raised_json(series, field, directory=DIRECTORY):
             file = json.load(f)
         if isinstance(file, dict) and file.get(JSON_KEY) in series:
             file.setdefault("raised vs spent", [{}])
-            file["raised vs spent"][0][field] = to_py_type(series[file[JSON_KEY]])
+            file["raised vs spent"][0][field] = str(series[file[JSON_KEY]])
             with open(path, "w") as f:
                 json.dump(file, f, indent=2)
                 f.write("\n")


### PR DESCRIPTION
Previously, numbers were being written as integers in the JSON files. This changes them to be written as strings.

This also includes some minor refactoring.