### PR TITLE
Round the float fields dealing with money to the nearest whole number in the candidate JSON files

### DIFF
--- a/src/scripts/candidate_calculation_amount_raised.py
+++ b/src/scripts/candidate_calculation_amount_raised.py
@@ -3,6 +3,8 @@
 Calculates the amount raised by each candidate by summing contributions
 from column `Tran_Amt1` in the CSV files and stores it in the
 candidate JSON files under field `file["raised vs spent"][0]["Raised"]`.
+
+The summed contributions are rounded to the nearest whole number.
 """
 
 from shared_calculations import (

--- a/src/scripts/candidate_calculation_amount_spent.py
+++ b/src/scripts/candidate_calculation_amount_spent.py
@@ -3,6 +3,8 @@
 Calculates the amount spent by each candidate by summing expenditures
 from column `Calculated_Amount` in the CSV files and stores it in the
 candidate JSON files under field `file["raised vs spent"][0]["Spent"]`.
+
+The summed contributions are rounded to the nearest whole number.
 """
 
 from shared_calculations import (

--- a/src/scripts/candidate_calculation_industry.py
+++ b/src/scripts/candidate_calculation_industry.py
@@ -4,6 +4,8 @@ Calculates the top five industries (taken from occupations) the candidate
 gets donations from, how much each industry donates, and the percentage
 of all the candidate's donations the industry donates in the candidate
 JSON files under field `file["by industry"][0]`.
+
+How much each industry donates is rounded to the nearest whole number.
 """
 
 import json
@@ -31,8 +33,9 @@ def process_occupation_df(df):
     summable column `Tran_Amt1` (the contributions).
 
     :returns: A dataframe with column `top_occupations` being the top 5
-    contributions and column `contribution_percent` being the corrosponding
-    percentage of the total contributions they each contributed.
+    contributions rounded to the nearest whole (int) number and column
+    `contribution_percent` being the corrosponding percentage of the
+    total contributions they each contributed.
     """
     sum_series = (
         df.groupby("Tran_Occ")["Tran_Amt1"].sum().nlargest(5).round().astype("int64")

--- a/src/scripts/candidate_calculation_industry.py
+++ b/src/scripts/candidate_calculation_industry.py
@@ -34,7 +34,9 @@ def process_occupation_df(df):
     contributions and column `contribution_percent` being the corrosponding
     percentage of the total contributions they each contributed.
     """
-    sum_series = df.groupby("Tran_Occ")["Tran_Amt1"].sum().nlargest(5)
+    sum_series = (
+        df.groupby("Tran_Occ")["Tran_Amt1"].sum().nlargest(5).round().astype("int64")
+    )
     contribution_sum = df["Tran_Amt1"].sum()
     return pd.DataFrame(
         {

--- a/src/scripts/shared_calculations.py
+++ b/src/scripts/shared_calculations.py
@@ -62,10 +62,17 @@ def summed_contributions(paths, types, column):
 
     :param column: The column to process
 
-    :returns: Pandas Series of the summed values with index column `CSV_KEY`
+    :returns: Pandas Series of the summed values with index column `CSV_KEY`.
+    The values are rounded, being converted to int64.
     """
     df = read_csv_df(paths, types, column)
-    return pd.Series(df[column], index=df.index).groupby(CSV_KEY).sum()
+    return (
+        pd.Series(df[column], index=df.index)
+        .groupby(CSV_KEY)
+        .sum()
+        .round()
+        .astype("int64")
+    )
 
 
 def to_py_type(value):


### PR DESCRIPTION
This rounds the values in the fields which are currently float numbers in the candidate JSON files to the nearest whole number.

This does not convert the new value to a string, see PR #69 for that.

The percentage that each industry donated to each candidate isn't currently rounded, should that be converted to an int and rounded? E.g, from 0.2468 to 25% (or 24.7%).