### PR TITLE
Industry table amount fix on candidate expansion card

### DIFF
--- a/src/app/components/candidate-card-expanded/candidate-card-expanded.component.html
+++ b/src/app/components/candidate-card-expanded/candidate-card-expanded.component.html
@@ -98,7 +98,7 @@
   
         <ng-container matColumnDef="amount">
           <th mat-header-cell *matHeaderCellDef>Amount</th>
-          <td [ngClass]="{'remove-border': i == dataSource.data.length - 1}" mat-cell *matCellDef="let element; let i = index">{{ element.amount | currency }}</td>
+          <td [ngClass]="{'remove-border': i == dataSource.data.length - 1}" mat-cell *matCellDef="let element; let i = index">{{ element.amount | currency:'USD':'symbol':'1.0-0' }}</td>
         </ng-container>
   
         <ng-container matColumnDef="percentage">

--- a/src/app/components/candidate-card-expanded/candidate-card-expanded.component.scss
+++ b/src/app/components/candidate-card-expanded/candidate-card-expanded.component.scss
@@ -104,6 +104,10 @@
             font-size: 13px;
             color: $vvgrey;
         }
+        
+        .mat-cell:nth-last-child(2) {
+            text-align: right;
+        }
 
         .mat-cell:last-child {
             font-size: 20px;


### PR DESCRIPTION
For the amount column on the candidate expansion card this right justifies the number and eliminates the decimals.
This addresses item 3 in issue #102. 