### PR TITLE
Industry table percentage display fix on candidate expansion card

### DIFF
--- a/src/app/components/candidate-card-expanded/candidate-card-expanded.component.html
+++ b/src/app/components/candidate-card-expanded/candidate-card-expanded.component.html
@@ -103,7 +103,7 @@
   
         <ng-container matColumnDef="percentage">
           <th mat-header-cell *matHeaderCellDef>Percentage</th>
-          <td [ngClass]="{'remove-border': i == dataSource.data.length - 1}" mat-cell *matCellDef="let element; let i = index">{{ element.percentage | percent }}</td>
+          <td [ngClass]="{'remove-border': i == dataSource.data.length - 1}" mat-cell *matCellDef="let element; let i = index">{{ element.percentage | number:'1.0-0' }}%</td>
         </ng-container>
   
         <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>

--- a/src/app/components/candidate-card-expanded/candidate-card-expanded.component.scss
+++ b/src/app/components/candidate-card-expanded/candidate-card-expanded.component.scss
@@ -108,6 +108,7 @@
         .mat-cell:last-child {
             font-size: 20px;
             font-weight: bold;
+            text-align: right;
         }
     }
 


### PR DESCRIPTION
For the percent column on the candidate expansion card this right justifies the number and removed two trailing zeros from the percentage. These percentages appear to be computed by dividing the industry amount by the total raised.
This addresses the formating relating to item 4 on issue #102. This does not address the computation of the percentage.