### PR TITLE
updated to show header row on industry table

### DIFF
--- a/src/app/components/candidate-card-expanded/candidate-card-expanded.component.html
+++ b/src/app/components/candidate-card-expanded/candidate-card-expanded.component.html
@@ -106,6 +106,7 @@
           <td [ngClass]="{'remove-border': i == dataSource.data.length - 1}" mat-cell *matCellDef="let element; let i = index">{{ element.percentage | number:'1.0-0' }}%</td>
         </ng-container>
   
+        <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
         <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
       </table>
     </div>

--- a/src/app/components/candidate-card-expanded/candidate-card-expanded.component.scss
+++ b/src/app/components/candidate-card-expanded/candidate-card-expanded.component.scss
@@ -105,14 +105,14 @@
             color: $vvgrey;
         }
         
-        .mat-cell:nth-last-child(2) {
+        .mat-cell:nth-last-child(2), .mat-cell:last-child, 
+        .mat-header-cell:nth-last-child(2), .mat-header-cell:last-child {
             text-align: right;
         }
 
-        .mat-cell:last-child {
+        .mat-cell:last-child, {
             font-size: 20px;
             font-weight: bold;
-            text-align: right;
         }
     }
 


### PR DESCRIPTION
The header row on the industry table was there but not showing. It now shows up.
Fixes Item 1 on #102 

![chrome_2020-09-22_18-37-02](https://user-images.githubusercontent.com/1051611/93954428-8d439580-fd02-11ea-8fd4-219183b48b24.png)
