### PR TITLE
Changed folder path for city council candidates

### DIFF
--- a/src/assets/candidates/2020/candidates.json
+++ b/src/assets/candidates/2020/candidates.json
@@ -16,36 +16,36 @@
     "city-council-district-1": {
         "title": "City Council - District One",
         "candidates": {
-            "Joe LaCava": "assets/candidates/2020/city_council_district_1/joe_lacava/joe_lacava.json",
-            "Will Moore": "assets/candidates/2020/city_council_district_1/will_moore/will_moore.json"
+            "Joe LaCava": "assets/candidates/2020/city_council/district_1/joe_lacava/joe_lacava.json",
+            "Will Moore": "assets/candidates/2020/city_council/district_1/will_moore/will_moore.json"
         }
     },
     "city-council-district-3": {
         "title": "City Council - District Three",
         "candidates": {
-            "Toni Duran": "assets/candidates/2020/city_council_district_3/toni_duran/toni_duran.json",
-            "Stephen Whitburn": "assets/candidates/2020/city_council_district_3/stephen_whitburn/stephen_whitburn.json"
+            "Toni Duran": "assets/candidates/2020/city_council/district_3/toni_duran/toni_duran.json",
+            "Stephen Whitburn": "assets/candidates/2020/city_council/district_3/stephen_whitburn/stephen_whitburn.json"
         }
     },
     "city-council-district-5": {
         "title": "City Council - District Five",
         "candidates": {
-            "Joe Leventhal": "assets/candidates/2020/city_council_district_5/joe_leventhal/joe_leventhal.json",
-            "Marni von Wilpert": "assets/candidates/2020/city_council_district_5/marni_von_wilpert/marni_von_wilpert.json"
+            "Joe Leventhal": "assets/candidates/2020/city_council/district_5/joe_leventhal/joe_leventhal.json",
+            "Marni von Wilpert": "assets/candidates/2020/city_council/district_5/marni_von_wilpert/marni_von_wilpert.json"
         }
     },
     "city-council-district-7": {
         "title": "City Council - District Seven",
         "candidates": {
-            "Raul Campillo": "assets/candidates/2020/city_council_district_7/raul_campillo/raul_campillo.json",
-            "Noli Zosa": "assets/candidates/2020/city_council_district_7/noli_zosa/noli_zosa.json"
+            "Raul Campillo": "assets/candidates/2020/city_council/district_7/raul_campillo/raul_campillo.json",
+            "Noli Zosa": "assets/candidates/2020/city_council/district_7/noli_zosa/noli_zosa.json"
         }
     },
     "city-council-district-9": {
         "title": "City Council - District Nine",
         "candidates": {
-            "Kelvin H. Barrios": "assets/candidates/2020/city_council_district_9/kelvin_h._barrios/kelvin_h._barrios.json",
-            "Sean Elo": "assets/candidates/2020/city_council_district_9/sean_elo/sean_elo.json"
+            "Kelvin H. Barrios": "assets/candidates/2020/city_council/district_9/kelvin_h._barrios/kelvin_h._barrios.json",
+            "Sean Elo": "assets/candidates/2020/city_council/district_9/sean_elo/sean_elo.json"
         }
     }
 }


### PR DESCRIPTION
This changes the location that the json files are read from for the city council candidates.

New folder path example:
`assets/candidates/2020/city_council/district_1/joe_lacava/joe_lacava.json`

Old folder path example:
`assets/candidates/2020/city_council_district_1/joe_lacava/joe_lacava.json`