### PR TITLE
added skip-download flag to driver_script.js

### DIFF
--- a/src/scripts/driver_script.js
+++ b/src/scripts/driver_script.js
@@ -10,19 +10,20 @@ const ASSETS_PATH = `${__dirname}/../assets/data`;
 function processInput() {
 
   var args = require('yargs')
-    .usage('Usage: $0 [--download boolean]')
-    .example('$0 --download false')
-    .example('$0 --download=true')
-    .option('download', {
-        default:  true,
-        describe: `Download csv files from Firebase Storage.`,
+    .usage('Usage: $0 [--skip-download boolean]')
+    .example('$0 --skip-download')
+    .example('$0 --sk')
+    .example('$0 --sk=true')
+    .option('skip-download', {
+        default:  false,
+        describe: `Do not download csv files.`,
         type: 'boolean'
     })
-    .alias('d', 'download')
+    .alias('sk', 'skip-download')
     .version(false)
     .argv;
 
-    return { downloadCSV: args.download }
+    return { downloadCSV: !args['skip-download'] }
 }
 
  /**

--- a/src/scripts/driver_script.js
+++ b/src/scripts/driver_script.js
@@ -6,6 +6,24 @@ const { execSync } = require("child_process");
 const CSV_FILE_NAMES = [ 'netfile_api_2018.csv', 'netfile_api_2019.csv', 'netfile_api_2020.csv' ];
 const ASSETS_PATH = `${__dirname}/../assets/data`;
 
+function processInput() {
+
+  var args = require('yargs')
+    .usage('Usage: $0 [--download boolean]')
+    .example('$0 --download false')
+    .example('$0 --download=true')
+    .option('download', {
+        default:  true,
+        describe: `Download csv files from Firebase Storage.`,
+        type: 'boolean'
+    })
+    .alias('d', 'download')
+    .version(false)
+    .argv;
+
+    return { downloadCSV: args.download }
+}
+
 async function downloadCSVFromFirebaseCloudStorage (fileNames, filePath){
   const encodedPath = encodeURIComponent('data/');
 
@@ -43,7 +61,11 @@ function getPythonCommand() {
 
 
 (async () => {
-  await downloadCSVFromFirebaseCloudStorage(CSV_FILE_NAMES, ASSETS_PATH);
+  const input = processInput();
+
+  if (input.downloadCSV) {
+    await downloadCSVFromFirebaseCloudStorage(CSV_FILE_NAMES, ASSETS_PATH);
+  }
 
   const pythonCommand = getPythonCommand();
 


### PR DESCRIPTION
Add a flag to driver_script.js to support skipping the download of the csv files from Firebase Stored. This is needed to run in a Github action where the csv files are downloaded from the Github API.

```
Usage: driver_script.js [--skip-download boolean]

Options:
  --help                 Show help                                     [boolean]
  --sk, --skip-download  Do not download csv files.                    [boolean]

Examples:
  driver_script.js --skip-download
  driver_script.js --sk
  driver_script.js --sk=true
```