### PR TITLE
Switch source contribution data column for "average_donation_calculation.py" to Tran_Amt1

### DIFF
--- a/src/scripts/average_donation_calculation.py
+++ b/src/scripts/average_donation_calculation.py
@@ -60,5 +60,5 @@ def to_json(series, directory=DIRECTORY):
 
 if __name__ == "__main__":
     to_json(
-        average_donation(read_csv_series(CSV_PATHS, CONTRIBUTION_TYPE, "Tran_Amt2"))
+        average_donation(read_csv_series(CSV_PATHS, CONTRIBUTION_TYPE, "Tran_Amt1"))
     )


### PR DESCRIPTION
There are two source columns in the source CSV files for how much was contributed to a candidate, Tran_Amt1 and Tran_Amt2. This switches it so that in "average_donation_calculation.py" Tran_Amt1 is used instead of Tran_Amt2. This makes it consistent with the other calculation scripts.