### PR TITLE
Fix to compare Filer/Committee names in same case for in vs out calculation

### DIFF
--- a/src/scripts/candidate_calculation_in_vs_out.js
+++ b/src/scripts/candidate_calculation_in_vs_out.js
@@ -69,7 +69,8 @@ function calculateCandidateGroupSum( office, candidates, sumKeyField, transactio
     const entries = transactionsGroups.map( group => { 
 
       let transactionsFound = group.transactions
-        .filter( transaction => transaction['FilerName'] === candidate['Committee Name (Filer_Name)'] ); // #5, #7
+        .filter( transaction => 
+          transaction['FilerName'].toLocaleLowerCase() === candidate['Committee Name (Filer_Name)'].toLocaleLowerCase() ); // #5, #7
       
       transactionsFound = shared.filterListOnKeyByArray( transactionsFound, formTypeKey, formTypes ); // #5, #7
 


### PR DESCRIPTION
The FilerName field from the CSV files is compared to Committee Name (Filer_Name) in the Google Sheet to determine matching
committees. This change does the comparison using the same case so that committee names with non matching case are not missed. This fix is for the in vs out calculation.