### PR TITLE
Update in vs out to use district zip codes

### DIFF
--- a/src/scripts/candidate_calculation_in_vs_out.js
+++ b/src/scripts/candidate_calculation_in_vs_out.js
@@ -77,7 +77,8 @@ function calculateCandidateGroupSum( office, candidates, sumKeyField, transactio
     const entries = transactionsGroups.map( group => { 
 
       let transactionsFound = group.transactions
-        .filter( transaction => transaction['FilerName'] === candidate['Committee Name (Filer_Name)'] ); // #5, #7
+        .filter( transaction => 
+          transaction['FilerName'].toLocaleLowerCase() === candidate['Committee Name (Filer_Name)'].toLocaleLowerCase() ); // #5, #7
       
       transactionsFound = shared.filterListOnKeyByArray( transactionsFound, formTypeKey, formTypes ); // #5, #7
 
@@ -144,22 +145,21 @@ function getInVsOutSums(candidate, transactions, zipCodeKey, zipCodeList) {
 (async () => {
 
   const zipCodeKey = 'Tran_Zip4';
-  // const offices = [ 'Mayor', 'City Council', 'City Attorney' ];
   const officesWholeCity = [ 'Mayor', 'City Attorney' ];
   const officesPerDistrict = [ 'City Council' ];
   const sumsField = 'inAndOut';
 
   // The valid zip code list as an array of strings from a local CSV file
-  const zipCodes = getZipCodes(); // #4
+  const zipCodesWholeCity = getZipCodes(); // #4
   
-  let zipCodesWithDistrict = getZipCodesWithDistricts();
+  const zipCodesWithDistrict = getZipCodesWithDistricts();
 
   // From the local CSV files
   const transactions = shared.getTransactions(); // #5 
 
   const transactionsGroups = [ // inside vs outside of city
-    { type: 'in',  transactions: shared.filterListOnKeyByArray( transactions, zipCodeKey, zipCodes) }, 
-    { type: 'out', transactions: shared.filterListOnKeyByNotInArray( transactions, zipCodeKey, zipCodes) }, 
+    { type: 'in',  transactions: shared.filterListOnKeyByArray( transactions, zipCodeKey, zipCodesWholeCity) }, 
+    { type: 'out', transactions: shared.filterListOnKeyByNotInArray( transactions, zipCodeKey, zipCodesWholeCity) }, 
   ];
 
   let districtsWithZipCodes = getDistrictsWithZipCodes(zipCodesWithDistrict);

--- a/src/scripts/candidate_calculation_in_vs_out.js
+++ b/src/scripts/candidate_calculation_in_vs_out.js
@@ -46,6 +46,8 @@ function getZipCodes(){
   return zipCodesData.map( element => element.zip_code );
 }
 
+  // returned data structure:
+  // [ { zipcode: "12345", "district 1": "1.0", "district 2": "0.0", ... }, { }, ... ]
 function getZipCodesWithDistricts() {
   const zipCodesFileName = 'sd_district_zipcodes.csv';
 
@@ -94,6 +96,8 @@ function calculateCandidateGroupSum( office, candidates, sumKeyField, transactio
   });
 }
 
+  // returned data structure:
+  // [ { districtName: "district 1", zipCodes: [ '12345', '23456', ... ] }, { }, ... ] 
 function getDistrictsWithZipCodes(zipCodesWithDistrict) {
   // This is the header row of the cvs file excluding the first column header
   const districtNames = (Object.keys(zipCodesWithDistrict[0])).slice(1);
@@ -141,7 +145,7 @@ function getInVsOutSums(candidate, transactions, zipCodeKey, zipCodeList) {
 (async () => {
 
   const zipCodeKey = 'Tran_Zip4';
-  const offices = [ 'Mayor', 'City Council', 'City Attorney' ];
+  // const offices = [ 'Mayor', 'City Council', 'City Attorney' ];
   const officesWholeCity = [ 'Mayor', 'City Attorney' ];
   const officesPerDistrict = [ 'City Council' ];
   const sumsField = 'inAndOut';
@@ -150,9 +154,6 @@ function getInVsOutSums(candidate, transactions, zipCodeKey, zipCodeList) {
   const zipCodes = getZipCodes(); // #4
   
   let zipCodesWithDistrict = getZipCodesWithDistricts();
-  // zipCodesWithDistrict data structure:
-  // [ { zipcode: "12345", "district 1": "1.0", "district 2": "0.0", ... }, { }, ... ]
-  // /* testing */ console.log('zipCodesWithDistrict', zipCodesWithDistrict);
 
   // From the local CSV files
   const transactions = shared.getTransactions(); // #5 
@@ -162,20 +163,14 @@ function getInVsOutSums(candidate, transactions, zipCodeKey, zipCodeList) {
     { type: 'out', transactions: shared.filterListOnKeyByNotInArray( transactions, zipCodeKey, zipCodes) }, 
   ];
 
-  // const districtsWithZipCodes = getDistrictsWithZipCodes(zipCodesWithDistrict);
-  // const cityCouncilTransactionsGroups ;
-
   let districtsWithZipCodes = getDistrictsWithZipCodes(zipCodesWithDistrict);
-  // zipCodesWithDistrict data structure:
-  // [ { districtName: "district 1", zipCodes: [ '12345', '23456', ... ] }, { }, ... ] 
-  // /* testing */ console.log('districtsWithZipCodes', districtsWithZipCodes);
 
   // From an online Google Sheet 
   const candidates = await shared.getCandidateInformation(); // #1 
 
   officesWholeCity
-  .map( office => calculateCandidateGroupSum( office, candidates, sumsField, transactionsGroups ) )
-  // .map( candidatesWithSums => shared.saveCandidatesDataToFiles( candidatesWithSums, sumsField, writeToInOutCallback ) );
+    .map( office => calculateCandidateGroupSum( office, candidates, sumsField, transactionsGroups ) )
+    .map( candidatesWithSums => shared.saveCandidatesDataToFiles( candidatesWithSums, sumsField, writeToInOutCallback ) );
 
 
   let candidatesWithDistricts = candidates

--- a/src/scripts/candidate_calculation_in_vs_out_district.js
+++ b/src/scripts/candidate_calculation_in_vs_out_district.js
@@ -1,0 +1,109 @@
+const shared = require('./shared_routines.js');
+const sharedInVOut = require('./candidate_calculation_in_vs_out_shared.js');
+
+
+/**
+ * This reads zip code and district data from a local csv file. This returns 
+ *  an array of objects that each contain a zip code and with districts 1 to 9.
+ *  Each district uses a 1.0 to indicate if the district contains the zip code and
+ *  a 0.0 if it does not. Zip codes can be within multiple districts.
+ * @returns {object[]} - 
+ *    [ { 'zipcode': '12345', 'district 1': '1.0', 'district 2': '0.0', ..., 'district 9': '1.0' }, ... ]
+ */
+function getZipCodesWithinDistricts() {
+  const zipCodesFileName = 'sd_district_zipcodes.csv';
+
+  const fileData = shared.getAssetsDataFromLocalFile( zipCodesFileName ); 
+  return shared.parseCSVDataToObjects( fileData );
+}
+  
+/**
+ * This takes an array of zip codes with districts and returns an array of 
+ *  districts that contain an array of zip codes within them.
+ * @param {object[]} zipCodesWithinDistrict - 
+ *    [ { 'zipcode': '12345', 'district 1': '1.0', ..., 'district 9': '1.0' }, ... ]
+ * @returns {object[]} - 
+ *    [ { districtName: "district 1", zipCodes: [ '12345', '23456', ... ] }, { }, ... ]
+ */
+function getDistrictsWithZipCodes(zipCodesWithinDistrict) {
+  // This is the header row of the cvs file excluding the first column header ('zipcode')
+  //  Keys: 'zipcode','district 1', ... ,'district 9'
+  //  Result: 'district 1', ... ,'district 9'
+  const districtNames = (Object.keys(zipCodesWithinDistrict[0])).slice(1);
+
+  const districtZipCodes = districtNames
+    .map( district => {
+      const zipCodes = zipCodesWithinDistrict
+        .filter( zipData => zipData[district] === '1.0' )
+        .map( zipData => zipData['zipcode'] )
+
+      return { districtName: district, zipCodes }
+    })
+
+  return districtZipCodes;
+}
+
+
+/**
+ * Compares the transactions to find those for a candidate where the zip code matches one from a given list.
+ *  Then split the lists and return the sum of a key from each list.
+ * @param {object} candidate - The fields associated with a candidate originating from a Google Sheet  
+ * @param {object[]} transactions - Multiple years of NetFile transactions loaded from a CSV file
+ * @param {string} zipCodeKey - Field within each transaction compare to  
+ * @param {string[]} zipCodeList - List of zip code to compare zipCodeKey to
+ * @returns {object[]} - { in: '1234', out: '4321' }
+ */
+function getInVsOutSums(candidate, transactions, zipCodeKey, zipCodeList) {
+  const transactionAmountKey = 'Tran_Amt1';
+  const formTypeKey = 'Form_Type';
+  const formTypes = [ 'A', 'C', 'I' ];
+
+  // Find all transactions associated with a candidate's committee
+  let transactionsFound = transactions
+    .filter( transaction => transaction['FilerName'].toLowerCase() === candidate['Committee Name (Filer_Name)'].toLowerCase() ); // #5, #7
+
+  // Filter the transactions to those where the field formTypeKey is one of the values in field formTypes
+  transactionsFound = shared.filterListOnKeyByArray( transactionsFound, formTypeKey, formTypes ); // #5, #7
+  
+  // Split the filtered transactions into two lists. One list are those transactions where the field zipCodeKey
+  // contains a values in zipCodeList and the other list are those that do not contain a value in zipCodeList. 
+  const transactionsIn = shared.filterListOnKeyByArray( transactionsFound, zipCodeKey, zipCodeList);
+  const transactionsOut = shared.filterListOnKeyByNotInArray( transactionsFound, zipCodeKey, zipCodeList);
+
+  return { // Get the sum of each of the two lists and convert each to a string with no decimal places
+    in: shared.sumKeyInList( transactionsIn, transactionAmountKey ).toFixed(0),
+    out: shared.sumKeyInList( transactionsOut, transactionAmountKey ).toFixed(0),
+  }
+}
+
+
+// Main entry function of script
+(async () => {
+  const officesPerDistrict = [ 'City Council' ];
+  const officeKey = 'Office';
+  const zipCodesWithinDistrict = getZipCodesWithinDistricts();
+  const districtsWithZipCodes = getDistrictsWithZipCodes(zipCodesWithinDistrict);
+
+  // From the local CSV files
+  const transactions = shared.getTransactions(); // #5 
+
+  // From an online Google Sheet 
+  const candidates = await shared.getCandidateInformation(); // #1 
+
+  let candidatesWithDistricts = shared.filterListOnKeyByArray( candidates, officeKey, officesPerDistrict )
+
+  candidatesWithDistricts = candidatesWithDistricts//.slice(0, 2)
+    .map( candidate => {
+      // get the zip codes for each candidate's district
+      const zipCodeList = districtsWithZipCodes
+        .find( district => district.districtName.toLowerCase() === `district ${candidate['District']}`.toLowerCase() );
+
+      // add a field to each candidate to store the in and out sums, Example { in: '1234', out: '4321' }
+      candidate[sharedInVOut.sumsField] = getInVsOutSums( candidate, transactions, sharedInVOut.zipCodeKey, zipCodeList['zipCodes'] );
+
+      return candidate;
+    });
+
+  shared.saveCandidatesDataToFiles( candidatesWithDistricts, sharedInVOut.sumsField, sharedInVOut.writeToInOutCallback );
+
+})();

--- a/src/scripts/candidate_calculation_in_vs_out_shared.js
+++ b/src/scripts/candidate_calculation_in_vs_out_shared.js
@@ -1,0 +1,38 @@
+
+ /**
+  * This checks to see if a 'key' exists in the 'jsonData' and
+  *  if not then assign it a value to match that from a given json file.
+  * @param {object} object - this is a structured json file data
+  * @param {string} key 
+  * @returns {object}
+  */
+ function createPropertyIfNotExist(jsonData, key) {
+  if ( !jsonData.hasOwnProperty(key) ) {
+    jsonData[key] = [ { } ];
+  }
+
+  return jsonData;
+}
+
+/**
+ * This updates the given 'jsonData' to add a value to specific property.
+ *  This is needed to match the format of the data stored in the json file.
+ * @param {string} value 
+ * @param {object} jsonData
+ * @returns {object}
+ */
+function writeToInOutCallback( value, jsonData ) {
+  const key = "in vs out district";
+  jsonData = createPropertyIfNotExist(jsonData, key);
+
+  jsonData[key][0] = value;
+
+  return jsonData;
+}
+
+
+module.exports = {
+  writeToInOutCallback,
+  zipCodeKey: 'Tran_Zip4',
+  sumsField: 'inAndOut',
+};

--- a/src/scripts/driver_script.js
+++ b/src/scripts/driver_script.js
@@ -113,6 +113,7 @@ function getPythonCommand() {
   const nodeScripts = [
     'candidate_calc_outside_spending.js',
     'candidate_calculation_in_vs_out.js',
+    'candidate_calculation_in_vs_out_district.js',
   ];
 
   nodeScripts.forEach( scriptFile => {


### PR DESCRIPTION
Revises City Council calculations to use a set of zip codes and district values to indicate the zip codes in each district. The City Council calculations are done in a separate script file and a call to it is added to driver_script.js. Functions used in new and existing **in vs out** calculations are moved to a new script file. 

Fixes #168