### PR TITLE
add .env to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ npm-debug.log
 yarn-error.log
 testem.log
 /typings
+/.env
 
 # System Files
 .DS_Store


### PR DESCRIPTION
This adds a **/.env** entry to the .gitignore file.  This allows a **.env** file to be placed in the root of the project to store per user API tokens but not have them be commit to version control.
