### PR TITLE
Script to calculate how many candidates are in each race

### DIFF
--- a/src/scripts/calculation_download_gdrive_info.py
+++ b/src/scripts/calculation_download_gdrive_info.py
@@ -17,8 +17,7 @@ import math
 import os
 import typing
 
-import pandas as pd
-from shared_calculations import DIRECTORY
+from shared_calculations import DIRECTORY, GOOGLE_SHEET_URL, read_candidate_csv
 
 EMPTY_MODEL_JSON = {
     "candidate name": "",
@@ -54,35 +53,6 @@ def replace_nan(value, replace):
     except TypeError:
         pass
     return value
-
-
-def read_candidate_csv(file):
-    """
-    Reads a Pandas Dataframe from a CSV file with candidate information.
-
-    If the row is completely empty, drops it.
-
-    :param file: A CSV file path (including URLS) or object that has
-    the columns being read.
-    :returns: The Pandas Dataframe with the CSV files information
-    """
-    return (
-        pd.read_csv(
-            file,
-            usecols=(
-                "Description",
-                "Website",
-                "Candidate_Name",
-                "Committee Name (Filer_Name)",
-                "Office",
-                "In General",
-                "District",
-                "Year",
-            ),
-        )
-        .dropna(how="all")
-        .set_index("Candidate_Name")
-    )
 
 
 def normalize(string, nan_replacement=None):
@@ -183,6 +153,5 @@ def update_json_files(folder_path, csv_url):
 
 if __name__ == "__main__":
     update_json_files(
-        DIRECTORY,
-        "https://docs.google.com/spreadsheets/d/1mENueYg0PhXE_MA9AypWWBJvBLdY03b8H_N_aIW-Ohw/export?format=csv&gid=0",
+        DIRECTORY, GOOGLE_SHEET_URL,
     )

--- a/src/scripts/number_of_candidates_calculation.py
+++ b/src/scripts/number_of_candidates_calculation.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""
+Calculates how many candidates are in the race for each office
+
+This calculates how many candidates are in the race for each office
+and writes them to "src/assets/candidates/campaign_candidate_totals.json".
+Its format is {"office": "count"}. The office is lowercased and the count is
+a string.
+
+It takes its data from the source google sheet
+(https://docs.google.com/spreadsheets/d/1mENueYg0PhXE_MA9AypWWBJvBLdY03b8H_N_aIW-Ohw/).
+"""
+from shared_calculations import GOOGLE_SHEET_URL, read_candidate_csv
+
+OUTPUT_TEMPLATE_PATH = "../assets/candidates/{year}/campaign_candidate_totals.json"
+
+
+def to_json(count_series, output_template_path=OUTPUT_TEMPLATE_PATH):
+    """
+    Outputs candidate count series to a JSON file with two spaces as the indent
+
+    The series's values are converted to strings
+
+    :param count_series: The series to be written. It should have a MultiIndex
+    with two levels, the first representing the year and the second
+    representing the office
+
+    :param output_template_path: The path of the JSON file, with "year"
+    as a format specifier for the election year.
+
+    :returns: None
+    """
+    count_series = count_series.astype(str)
+    count_series.index.levels[0].map(
+        lambda year: count_series[year].to_json(
+            output_template_path.format(year=year), indent=2
+        )
+    )
+
+
+def candidate_count(csv_path=GOOGLE_SHEET_URL):
+    """
+    Calculates how many candidates are in the race for each office by year
+
+    :param csv_path: The path or file object of the source CSV file
+    with the candidate information. Accepts URLs.
+
+    :returns: A Pandas series. Its index is a MultiIndex with the first
+    level being "Year" and the second level being "Office". The office's
+    name lower cased. The values are integer counts of how many candidates
+    are running for that office in that year.
+    """
+    count = read_candidate_csv(csv_path)
+    count["Office"] = count["Office"].str.lower()
+    return count.groupby(["Year", "Office"]).size()
+
+
+if __name__ == "__main__":
+    to_json(candidate_count())

--- a/src/scripts/shared_calculations.py
+++ b/src/scripts/shared_calculations.py
@@ -15,6 +15,8 @@ JSON_KEY = "committee name"
 
 DIRECTORY = "../assets/candidates/"
 
+GOOGLE_SHEET_URL = "https://docs.google.com/spreadsheets/d/1mENueYg0PhXE_MA9AypWWBJvBLdY03b8H_N_aIW-Ohw/export?format=csv&gid=0"
+
 CSV_PATHS = (
     "../assets/data/netfile_api_2020.csv",
     "../assets/data/netfile_api_2019.csv",
@@ -155,7 +157,7 @@ def candidate_files_map(function, directory=DIRECTORY):
 
     The field with its name in constant `JSON_KEY` is lower cased when
     passed to param `function`. The original case is restored when
-    writing to the JSON files. 
+    writing to the JSON files.
 
     :param function: A function that takes a single dictionary argument and
     returns a dictionary or None.
@@ -178,3 +180,32 @@ def candidate_files_map(function, directory=DIRECTORY):
                     json.dump(new_json_dict, file, indent=2)
                     file.write("\n")
                     file.truncate()
+
+
+def read_candidate_csv(file):
+    """
+    Reads a Pandas Dataframe from a CSV file with candidate information.
+
+    If the row is completely empty, drops it.
+
+    :param file: A CSV file path (including URLS) or object that has
+    the columns being read.
+    :returns: The Pandas Dataframe with the CSV files information
+    """
+    return (
+        pd.read_csv(
+            file,
+            usecols=(
+                "Description",
+                "Website",
+                "Candidate_Name",
+                "Committee Name (Filer_Name)",
+                "Office",
+                "In General",
+                "District",
+                "Year",
+            ),
+        )
+        .dropna(how="all")
+        .set_index("Candidate_Name")
+    )


### PR DESCRIPTION
This is a script that calculates how many candidates are in each race by year and outputs them to `/src/assets/candidates/{year}/campaign_candidate_totals.json`.

Closes #162.