### PR TITLE
removed cityCouncil conditional statement from home.component.html. 

### DIFF
--- a/src/app/components/home/home.component.html
+++ b/src/app/components/home/home.component.html
@@ -18,7 +18,7 @@
           <mat-expansion-panel (opened)="setOfficeStep(i)" hideToggle="true" (closed)="setCouncilDistrictStep(-1)">
 
             <mat-expansion-panel-header [ngClass]="{'active-link':officeStep===i}" collapsedHeight="50px" expandedHeight="50px" 
-               [routerLink]=" candidateType.key.toLowerCase() ==='city council'? []: '/'+ candidateType.key">
+               [routerLink]="candidateType.value.deepTree? []: '/'+ candidateType.key">
               <mat-panel-title>
                 {{candidateType.value.title}}
               </mat-panel-title>


### PR DESCRIPTION
now homecomponent.html has no reference to city council. the head of a deep tree does not have a router link to render a different component. eg:- when we click on mayor , mayor component is called , whereas when we click on city council, there is no component called city council which is called.