### PR TITLE
157: Remove "full details" link in candidate cards

### DIFF
--- a/src/app/components/candidate-card-expanded/candidate-card-expanded.component.html
+++ b/src/app/components/candidate-card-expanded/candidate-card-expanded.component.html
@@ -23,16 +23,12 @@
           <h3>{{candidate["raised vs spent"][0].Donors}}</h3>
         </div>
       </div>
-  
-      
-      <div>
-        <button class="full-details-btn" routerLink="/under-construction" mat-flat-button>See Full Details</button>
-      </div>
+
       <div class="website-link">
         <mat-icon>link</mat-icon>
         <a href="{{ candidate['website'] }}">Website</a>
       </div>
-  
+
     </div>
   </div>
   <div class="raised-spent">
@@ -50,7 +46,7 @@
           </sup>
         </p>
       </div>
-  
+
       <div class="raised-spent-chart chart-container-raised">
         <canvas baseChart
           width="350"
@@ -61,7 +57,7 @@
           [plugins]="chartPlugins"
         ></canvas>
       </div>
-  
+
       <div class="raised-spent-footer">
         <div class="avg-donation">
           <h2 class="raised-spent-footer-title">Average Donation</h2>
@@ -83,7 +79,7 @@
           </sup>
         </p>
       </div>
-  
+
 
 
     <div>
@@ -94,23 +90,23 @@
             <mat-icon>fiber_manual_record</mat-icon>
           </td>
         </ng-container>
-  
+
         <ng-container matColumnDef="industry">
           <th mat-header-cell *matHeaderCellDef>Industry</th>
           <td [ngClass]="{'remove-border': i == dataSource.data.length - 1}" mat-cell *matCellDef="let element; let i = index">{{ element.industry }}</td>
         </ng-container>
-  
+
         <ng-container matColumnDef="amount">
           <th mat-header-cell *matHeaderCellDef>Amount</th>
           <td [ngClass]="{'remove-border': i == dataSource.data.length - 1}" mat-cell *matCellDef="let element; let i = index">{{ element.amount | currency:'USD':'symbol':'1.0-0' }}</td>
         </ng-container>
-  
+
         <ng-container matColumnDef="percentage">
           <th mat-header-cell *matHeaderCellDef>Percentage</th>
           <td [ngClass]="{'remove-border': i == dataSource.data.length - 1}" mat-cell *matCellDef="let element; let i = index">{{ element.percentage | number:'1.0-0' }}%</td>
         </ng-container>
-  
-        
+
+
         <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
       </table>
     </div>
@@ -151,7 +147,7 @@
   <div class="close">
     <i style="font-size: 25px;" class="fa fa-times-circle" aria-hidden="true" (click)="close()"></i>
   </div>
-  
+
 
 
   <div class="outside-money">


### PR DESCRIPTION
Here's what the card looks like with "Full Details" button removed:
![image](https://user-images.githubusercontent.com/6019638/99895568-cf734f80-2c3d-11eb-9a0f-029567157e4a.png)
