### PR TITLE
Issue 159, Read mayor, city council and city attorney sums from JSON file

### DIFF
--- a/src/app/components/splash/splash.component.html
+++ b/src/app/components/splash/splash.component.html
@@ -31,7 +31,7 @@
             <h2 class="racename">Mayor</h2> 
             <a class="cta" routerLinkActive="active-link" routerLink="/mayor"><i class="fa fa-university"></i>See Candidates</a>
             <p class="raised">Total Raised</p>
-            <h3 class="amount_raised">${{ campaignTotals.mayor }}</h3>
+            <h3 class="amount_raised">${{ campaignTotals.mayor | roundCurrencyDisplay: 1 }}</h3>
             <p class="candidate_num">Candidates</p>
             <h3>{{ candidateCounts.mayor }}</h3>
         </div>
@@ -39,7 +39,7 @@
             <h2 class="racename">City Attorney</h2> 
             <a class="cta" routerLinkActive="active-link" routerLink="/city-attorney"><i class="fa fa-balance-scale"></i>See Candidates</a>
             <p class="raised">Total Raised</p>
-            <h3 class="amount_raised">${{ campaignTotals.cityAttorney }}</h3>
+            <h3 class="amount_raised">${{ campaignTotals.cityAttorney | roundCurrencyDisplay: 1 }}</h3>
             <p class="candidate_num">Candidates</p>
             <h3>{{ candidateCounts.cityAttorney }}</h3>
         </div>
@@ -47,7 +47,7 @@
             <h2 class="racename">City Council</h2> 
             <a class="cta" routerLinkActive="active-link" routerLink="/city-council"><i class="fas fa-map-marked-alt"></i>Choose District</a>
             <p class="raised">Total Raised</p>
-            <h3 class="amount_raised">${{ campaignTotals.cityCouncil }}</h3>
+            <h3 class="amount_raised">${{ campaignTotals.cityCouncil | roundCurrencyDisplay: 1 }}</h3>
             <p class="candidate_num">Candidates</p>
             <h3>{{ candidateCounts.cityCouncil }}</h3>
         </div>

--- a/src/app/components/splash/splash.component.html
+++ b/src/app/components/splash/splash.component.html
@@ -31,7 +31,7 @@
             <h2 class="racename">Mayor</h2> 
             <a class="cta" routerLinkActive="active-link" routerLink="/mayor"><i class="fa fa-university"></i>See Candidates</a>
             <p class="raised">Total Raised</p>
-            <h3 class="amount_raised">$1.5M</h3>
+            <h3 class="amount_raised">${{ campaignTotals.mayor }}</h3>
             <p class="candidate_num">Candidates</p>
             <h3>5</h3>
         </div>
@@ -39,7 +39,7 @@
             <h2 class="racename">City Attorney</h2> 
             <a class="cta" routerLinkActive="active-link" routerLink="/city-attorney"><i class="fa fa-balance-scale"></i>See Candidates</a>
             <p class="raised">Total Raised</p>
-            <h3 class="amount_raised">$1.5M</h3>
+            <h3 class="amount_raised">${{ campaignTotals.cityAttorney }}</h3>
             <p class="candidate_num">Candidates</p>
             <h3>5</h3>
         </div>
@@ -47,7 +47,7 @@
             <h2 class="racename">City Council</h2> 
             <a class="cta" routerLinkActive="active-link" routerLink="/city-council"><i class="fas fa-map-marked-alt"></i>Choose District</a>
             <p class="raised">Total Raised</p>
-            <h3 class="amount_raised">$1.5M</h3>
+            <h3 class="amount_raised">${{ campaignTotals.cityCouncil }}</h3>
             <p class="candidate_num">Candidates</p>
             <h3>5</h3>
         </div>

--- a/src/app/components/splash/splash.component.ts
+++ b/src/app/components/splash/splash.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnInit } from '@angular/core';
+import { CandidateService } from '../../services/candidate.service';
 
 @Component({
   selector: 'app-splash',
@@ -7,9 +8,17 @@ import { Component, OnInit } from '@angular/core';
 })
 export class SplashComponent implements OnInit {
 
-  constructor() { }
+  constructor(private candidateService: CandidateService) { }
+
+  campaignTotals = {
+    mayor: '0',
+    cityAttorney: '0',
+    cityCouncil: '0'
+  }
 
   ngOnInit() {
+    this.candidateService.getCampaignTotals()
+      .subscribe(totals => this.campaignTotals = totals);
   }
 
 }

--- a/src/app/pipes/round-currency-display.pipe.ts
+++ b/src/app/pipes/round-currency-display.pipe.ts
@@ -6,15 +6,15 @@ import { Pipe, PipeTransform } from "@angular/core";
 export class RoundCurrencyDisplayPipe implements PipeTransform {
   transform(input: any, args?: any): any {
     var exp,
-      rounded,
+      oneMillion = 1000000,
       suffixes = ["k", "M", "G", "T", "P", "E"];
 
     if (Number.isNaN(input)) {
       return null;
     }
-
-    if (input < 1000) {
-      return input;
+ 
+    if (input < oneMillion) {
+      return Number(input).toLocaleString('en-US');
     }
 
     exp = Math.floor(Math.log(input) / Math.log(1000));

--- a/src/app/services/candidate.service.ts
+++ b/src/app/services/candidate.service.ts
@@ -1,6 +1,7 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { Subject } from 'rxjs';
+import { Subject, Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
 import { CandidateTree } from '../candidate';
 
 @Injectable({
@@ -14,6 +15,23 @@ export class CandidateService {
 
   emitChangeFromSidenav(change: string) {
     this.emitChangeSidenav.next(change);
+  }
+
+  getCampaignTotals(): Observable<any> {
+    const campaignTotalsFilePath = "assets/candidates/2020/campaign_race_totals.json";
+
+    const campaignTotals = this.http.get<any>(campaignTotalsFilePath)
+      .pipe( // transform the property names used from those in the json file
+        map( result => {
+          return {
+            'mayor': result['mayor'],
+            'cityAttorney': result['city attorney'],
+            'cityCouncil': result['city council']
+          }
+        })
+      );
+
+    return campaignTotals;
   }
 
   getAll() {

--- a/src/app/services/candidate.service.ts
+++ b/src/app/services/candidate.service.ts
@@ -22,7 +22,7 @@ export class CandidateService {
 
     const campaignTotals = this.http.get<any>(campaignTotalsFilePath)
       .pipe( // transform the property names used from those in the json file
-        map( result => {
+        map(result => {
           return {
             'mayor': result['mayor'],
             'cityAttorney': result['city attorney'],
@@ -32,6 +32,12 @@ export class CandidateService {
       );
 
     return campaignTotals;
+  }
+
+  getCampaignTotalsByOffice(office: string): Observable<any> {
+    return this.getCampaignTotals().pipe(
+      map(offices => offices[office])
+    )
   }
 
   getAll() {


### PR DESCRIPTION
Adds candidate sums to splash page

The formating pipe from PR 222 should be used for the totals in the splash component after both it and this have been merged. This displays the amounts without rounding. For example for City Attorney the Total Raised shows as $639706.

Closes #159 