### PR TITLE
Update deploy_to_prod.yml

### DIFF
--- a/.github/workflows/deploy_to_prod.yml
+++ b/.github/workflows/deploy_to_prod.yml
@@ -44,4 +44,4 @@ jobs:
         with:
           args: deploy --only hosting --project=production
         env:
-          FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
+          FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN_PROD }}


### PR DESCRIPTION
The master branch failed to deploy to Firebase. 

A new token has been generated and added to repo as FIREBASE_TOKEN_PROD. The existing token used for the dev deployment is being left as FIREBASE_TOKEN. Previously the same token (FIREBASE_TOKEN) was used for both the dev and production deployments. 