### PR TITLE
Inside vs. Outside money standalone component

### DIFF
--- a/documentation.json
+++ b/documentation.json
@@ -1,0 +1,2791 @@
+{
+    "pipes": [
+        {
+            "name": "RoundCurrencyDisplayPipe",
+            "id": "pipe-RoundCurrencyDisplayPipe-b87e51ce06c5a439159a7eba5f7891b0",
+            "file": "src/app/pipes/round-currency-display.pipe.ts",
+            "type": "pipe",
+            "description": "",
+            "properties": [],
+            "methods": [
+                {
+                    "name": "transform",
+                    "args": [
+                        {
+                            "name": "input",
+                            "type": "any"
+                        },
+                        {
+                            "name": "args",
+                            "type": "any",
+                            "optional": true
+                        }
+                    ],
+                    "optional": false,
+                    "returnType": "any",
+                    "typeParameters": [],
+                    "line": 7,
+                    "jsdoctags": [
+                        {
+                            "name": "input",
+                            "type": "any",
+                            "tagName": {
+                                "text": "param"
+                            }
+                        },
+                        {
+                            "name": "args",
+                            "type": "any",
+                            "optional": true,
+                            "tagName": {
+                                "text": "param"
+                            }
+                        }
+                    ]
+                }
+            ],
+            "ngname": "roundCurrencyDisplay",
+            "sourceCode": "import { Pipe, PipeTransform } from \"@angular/core\";\r\n\r\n@Pipe({\r\n  name: \"roundCurrencyDisplay\",\r\n})\r\nexport class RoundCurrencyDisplayPipe implements PipeTransform {\r\n  transform(input: any, args?: any): any {\r\n    var exp,\r\n      oneMillion = 1000000,\r\n      suffixes = [\"k\", \"M\", \"G\", \"T\", \"P\", \"E\"];\r\n\r\n    if (Number.isNaN(input)) {\r\n      return null;\r\n    }\r\n \r\n    if (input < oneMillion) {\r\n      return Number(input).toLocaleString('en-US');\r\n    }\r\n\r\n    exp = Math.floor(Math.log(input) / Math.log(1000));\r\n\r\n    return (input / Math.pow(1000, exp)).toFixed(args) + suffixes[exp - 1];\r\n  }\r\n}\r\n"
+        }
+    ],
+    "interfaces": [
+        {
+            "name": "Candidate",
+            "id": "interface-Candidate-246b331498821bd3188aadd42d9261a5",
+            "file": "src/app/candidate.alt.ts",
+            "type": "interface",
+            "sourceCode": "export interface Candidate {\r\n    name: string;\r\n    title: string;\r\n    raised: string;\r\n    donors: string;\r\n}\r\n\r\nexport interface Candidate2 {\r\n  \"by industry\": [\r\n    { \"industry 1\": string[] },\r\n    { \"industry 2\": string[] },\r\n    { \"industry 3\": string[] },\r\n    { \"industry 4\": string[] },\r\n    { \"industry 5\": string[] },\r\n  ],\r\n  \"candidate name\": string,\r\n  \"committee name\": string,\r\n  \"description\": string,\r\n  \"first\": string,\r\n  \"in general\": boolean,\r\n  \"in vs out district\": [{\r\n    \"in\": string,\r\n    \"out\": string,\r\n  }],\r\n  \"last\": string,\r\n  \"oppose\": string,\r\n  \"raised vs spent\": [{\r\n    \"Raised\": string,\r\n    \"Spent\": string,\r\n    \"Donors\": string,\r\n    \"Average Donor\": string\r\n  }],\r\n  \"support\": string,\r\n  \"website\": string,\r\n}\r\n\r\nexport interface CandidateTree {\r\n    title: string;\r\n    name: string;\r\n    candidates: Record<string, string>;\r\n}\r\n",
+            "properties": [
+                {
+                    "name": "donors",
+                    "type": "string",
+                    "optional": false,
+                    "description": "",
+                    "line": 5
+                },
+                {
+                    "name": "name",
+                    "type": "string",
+                    "optional": false,
+                    "description": "",
+                    "line": 2
+                },
+                {
+                    "name": "raised",
+                    "type": "string",
+                    "optional": false,
+                    "description": "",
+                    "line": 4
+                },
+                {
+                    "name": "title",
+                    "type": "string",
+                    "optional": false,
+                    "description": "",
+                    "line": 3
+                }
+            ],
+            "indexSignatures": [],
+            "kind": 150,
+            "methods": []
+        },
+        {
+            "name": "Candidate",
+            "id": "interface-Candidate-32cd8119131c5916f178848d0e646cbf-1",
+            "file": "src/app/candidate.ts",
+            "type": "interface",
+            "sourceCode": "export interface Candidate {\r\n    name: string;\r\n    title: string;\r\n    raised: string;\r\n    donors: string;\r\n}\r\n\r\nexport interface CandidateTree {\r\n    title: string;\r\n    name: string;\r\n    candidates: Record<string, string>;\r\n}\r\n",
+            "properties": [
+                {
+                    "name": "donors",
+                    "type": "string",
+                    "optional": false,
+                    "description": "",
+                    "line": 5
+                },
+                {
+                    "name": "name",
+                    "type": "string",
+                    "optional": false,
+                    "description": "",
+                    "line": 2
+                },
+                {
+                    "name": "raised",
+                    "type": "string",
+                    "optional": false,
+                    "description": "",
+                    "line": 4
+                },
+                {
+                    "name": "title",
+                    "type": "string",
+                    "optional": false,
+                    "description": "",
+                    "line": 3
+                }
+            ],
+            "indexSignatures": [],
+            "kind": 150,
+            "methods": [],
+            "isDuplicate": true,
+            "duplicateId": 1,
+            "duplicateName": "Candidate-1"
+        },
+        {
+            "name": "Candidate2",
+            "id": "interface-Candidate2-246b331498821bd3188aadd42d9261a5",
+            "file": "src/app/candidate.alt.ts",
+            "type": "interface",
+            "sourceCode": "export interface Candidate {\r\n    name: string;\r\n    title: string;\r\n    raised: string;\r\n    donors: string;\r\n}\r\n\r\nexport interface Candidate2 {\r\n  \"by industry\": [\r\n    { \"industry 1\": string[] },\r\n    { \"industry 2\": string[] },\r\n    { \"industry 3\": string[] },\r\n    { \"industry 4\": string[] },\r\n    { \"industry 5\": string[] },\r\n  ],\r\n  \"candidate name\": string,\r\n  \"committee name\": string,\r\n  \"description\": string,\r\n  \"first\": string,\r\n  \"in general\": boolean,\r\n  \"in vs out district\": [{\r\n    \"in\": string,\r\n    \"out\": string,\r\n  }],\r\n  \"last\": string,\r\n  \"oppose\": string,\r\n  \"raised vs spent\": [{\r\n    \"Raised\": string,\r\n    \"Spent\": string,\r\n    \"Donors\": string,\r\n    \"Average Donor\": string\r\n  }],\r\n  \"support\": string,\r\n  \"website\": string,\r\n}\r\n\r\nexport interface CandidateTree {\r\n    title: string;\r\n    name: string;\r\n    candidates: Record<string, string>;\r\n}\r\n",
+            "properties": [
+                {
+                    "name": "by industry",
+                    "type": "[literal type, literal type, literal type, literal type, literal type]",
+                    "optional": false,
+                    "description": "",
+                    "line": 9
+                },
+                {
+                    "name": "candidate name",
+                    "type": "string",
+                    "optional": false,
+                    "description": "",
+                    "line": 16
+                },
+                {
+                    "name": "committee name",
+                    "type": "string",
+                    "optional": false,
+                    "description": "",
+                    "line": 17
+                },
+                {
+                    "name": "description",
+                    "type": "string",
+                    "optional": false,
+                    "description": "",
+                    "line": 18
+                },
+                {
+                    "name": "first",
+                    "type": "string",
+                    "optional": false,
+                    "description": "",
+                    "line": 19
+                },
+                {
+                    "name": "in general",
+                    "type": "boolean",
+                    "optional": false,
+                    "description": "",
+                    "line": 20
+                },
+                {
+                    "name": "in vs out district",
+                    "type": "[literal type]",
+                    "optional": false,
+                    "description": "",
+                    "line": 21
+                },
+                {
+                    "name": "last",
+                    "type": "string",
+                    "optional": false,
+                    "description": "",
+                    "line": 25
+                },
+                {
+                    "name": "oppose",
+                    "type": "string",
+                    "optional": false,
+                    "description": "",
+                    "line": 26
+                },
+                {
+                    "name": "raised vs spent",
+                    "type": "[literal type]",
+                    "optional": false,
+                    "description": "",
+                    "line": 27
+                },
+                {
+                    "name": "support",
+                    "type": "string",
+                    "optional": false,
+                    "description": "",
+                    "line": 33
+                },
+                {
+                    "name": "website",
+                    "type": "string",
+                    "optional": false,
+                    "description": "",
+                    "line": 34
+                }
+            ],
+            "indexSignatures": [],
+            "kind": 150,
+            "methods": []
+        },
+        {
+            "name": "CandidateTree",
+            "id": "interface-CandidateTree-246b331498821bd3188aadd42d9261a5",
+            "file": "src/app/candidate.alt.ts",
+            "type": "interface",
+            "sourceCode": "export interface Candidate {\r\n    name: string;\r\n    title: string;\r\n    raised: string;\r\n    donors: string;\r\n}\r\n\r\nexport interface Candidate2 {\r\n  \"by industry\": [\r\n    { \"industry 1\": string[] },\r\n    { \"industry 2\": string[] },\r\n    { \"industry 3\": string[] },\r\n    { \"industry 4\": string[] },\r\n    { \"industry 5\": string[] },\r\n  ],\r\n  \"candidate name\": string,\r\n  \"committee name\": string,\r\n  \"description\": string,\r\n  \"first\": string,\r\n  \"in general\": boolean,\r\n  \"in vs out district\": [{\r\n    \"in\": string,\r\n    \"out\": string,\r\n  }],\r\n  \"last\": string,\r\n  \"oppose\": string,\r\n  \"raised vs spent\": [{\r\n    \"Raised\": string,\r\n    \"Spent\": string,\r\n    \"Donors\": string,\r\n    \"Average Donor\": string\r\n  }],\r\n  \"support\": string,\r\n  \"website\": string,\r\n}\r\n\r\nexport interface CandidateTree {\r\n    title: string;\r\n    name: string;\r\n    candidates: Record<string, string>;\r\n}\r\n",
+            "properties": [
+                {
+                    "name": "candidates",
+                    "type": "Record<string | string>",
+                    "optional": false,
+                    "description": "",
+                    "line": 40
+                },
+                {
+                    "name": "name",
+                    "type": "string",
+                    "optional": false,
+                    "description": "",
+                    "line": 39
+                },
+                {
+                    "name": "title",
+                    "type": "string",
+                    "optional": false,
+                    "description": "",
+                    "line": 38
+                }
+            ],
+            "indexSignatures": [],
+            "kind": 150,
+            "methods": []
+        },
+        {
+            "name": "CandidateTree",
+            "id": "interface-CandidateTree-32cd8119131c5916f178848d0e646cbf-1",
+            "file": "src/app/candidate.ts",
+            "type": "interface",
+            "sourceCode": "export interface Candidate {\r\n    name: string;\r\n    title: string;\r\n    raised: string;\r\n    donors: string;\r\n}\r\n\r\nexport interface CandidateTree {\r\n    title: string;\r\n    name: string;\r\n    candidates: Record<string, string>;\r\n}\r\n",
+            "properties": [
+                {
+                    "name": "candidates",
+                    "type": "Record<string | string>",
+                    "optional": false,
+                    "description": "",
+                    "line": 11
+                },
+                {
+                    "name": "name",
+                    "type": "string",
+                    "optional": false,
+                    "description": "",
+                    "line": 10
+                },
+                {
+                    "name": "title",
+                    "type": "string",
+                    "optional": false,
+                    "description": "",
+                    "line": 9
+                }
+            ],
+            "indexSignatures": [],
+            "kind": 150,
+            "methods": [],
+            "isDuplicate": true,
+            "duplicateId": 1,
+            "duplicateName": "CandidateTree-1"
+        }
+    ],
+    "injectables": [
+        {
+            "name": "CandidateService",
+            "id": "injectable-CandidateService-fbca2523ed5a375084f8cf8ad11ab017",
+            "file": "src/app/services/candidate.service.ts",
+            "properties": [
+                {
+                    "name": "http",
+                    "type": "HttpClient",
+                    "optional": false,
+                    "description": "",
+                    "line": 12,
+                    "modifierKind": [
+                        114
+                    ]
+                }
+            ],
+            "methods": [
+                {
+                    "name": "getAll",
+                    "args": [],
+                    "optional": false,
+                    "returnType": "any",
+                    "typeParameters": [],
+                    "line": 37
+                },
+                {
+                    "name": "getCampaignTotals",
+                    "args": [],
+                    "optional": false,
+                    "returnType": "Observable<any>",
+                    "typeParameters": [],
+                    "line": 14
+                },
+                {
+                    "name": "getCampaignTotalsByOffice",
+                    "args": [
+                        {
+                            "name": "office",
+                            "type": "string"
+                        }
+                    ],
+                    "optional": false,
+                    "returnType": "Observable<any>",
+                    "typeParameters": [],
+                    "line": 31,
+                    "jsdoctags": [
+                        {
+                            "name": "office",
+                            "type": "string",
+                            "tagName": {
+                                "text": "param"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "name": "getCityAttorneys",
+                    "args": [],
+                    "optional": false,
+                    "returnType": "any",
+                    "typeParameters": [],
+                    "line": 74
+                },
+                {
+                    "name": "getCityCouncilorsByDistrict",
+                    "args": [
+                        {
+                            "name": "districtNumber",
+                            "type": "string"
+                        }
+                    ],
+                    "optional": false,
+                    "returnType": "any",
+                    "typeParameters": [],
+                    "line": 83,
+                    "jsdoctags": [
+                        {
+                            "name": "districtNumber",
+                            "type": "string",
+                            "tagName": {
+                                "text": "param"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "name": "getLastUpdated",
+                    "args": [],
+                    "optional": false,
+                    "returnType": "Observable<any>",
+                    "typeParameters": [],
+                    "line": 93
+                },
+                {
+                    "name": "getMayors",
+                    "args": [],
+                    "optional": false,
+                    "returnType": "any",
+                    "typeParameters": [],
+                    "line": 65
+                },
+                {
+                    "name": "getNumberOfCandidates",
+                    "args": [],
+                    "optional": false,
+                    "returnType": "Observable<any>",
+                    "typeParameters": [],
+                    "line": 41
+                },
+                {
+                    "name": "getNumberOfCandidatesByOffice",
+                    "args": [
+                        {
+                            "name": "office",
+                            "type": "string"
+                        }
+                    ],
+                    "optional": false,
+                    "returnType": "Observable<any>",
+                    "typeParameters": [],
+                    "line": 58,
+                    "jsdoctags": [
+                        {
+                            "name": "office",
+                            "type": "string",
+                            "tagName": {
+                                "text": "param"
+                            }
+                        }
+                    ]
+                }
+            ],
+            "description": "",
+            "sourceCode": "import { HttpClient } from '@angular/common/http';\r\nimport { Injectable } from '@angular/core';\r\nimport { Observable } from 'rxjs';\r\nimport { map } from 'rxjs/operators';\r\nimport { CandidateTree } from '../candidate';\r\n\r\n@Injectable({\r\n  providedIn: 'root'\r\n})\r\nexport class CandidateService {\r\n\r\n  constructor(public http: HttpClient) { }\r\n\r\n  getCampaignTotals(): Observable<any> {\r\n    const campaignTotalsFilePath = \"assets/candidates/2020/campaign_race_totals.json\";\r\n\r\n    const campaignTotals = this.http.get<any>(campaignTotalsFilePath)\r\n      .pipe( // transform the property names used from those in the json file\r\n        map(result => {\r\n          return {\r\n            'mayor': result['mayor'],\r\n            'cityAttorney': result['city attorney'],\r\n            'cityCouncil': result['city council']\r\n          }\r\n        })\r\n      );\r\n\r\n    return campaignTotals;\r\n  }\r\n\r\n  getCampaignTotalsByOffice(office: string): Observable<any> {\r\n    return this.getCampaignTotals().pipe(\r\n      map(offices => offices[office])\r\n    )\r\n  }\r\n\r\n  getAll() {\r\n    return this.http.get(\"assets/candidates/2020/candidates.json\").toPromise();\r\n  }\r\n\r\n  getNumberOfCandidates(): Observable<any> {\r\n    const campaignCandidateTotalsFilePath = \"assets/candidates/2020/campaign_candidate_totals.json\";\r\n\r\n    const candidateCounts = this.http.get<any>(campaignCandidateTotalsFilePath)\r\n      .pipe( // transform the property names used from those in the json file\r\n        map(result => {\r\n          return {\r\n            'mayor': result['mayor'],\r\n            'cityAttorney': result['city attorney'],\r\n            'cityCouncil': result['city council']\r\n          }\r\n        })\r\n      );\r\n\r\n    return candidateCounts;\r\n  }\r\n\r\n  getNumberOfCandidatesByOffice(office: string): Observable<any> {\r\n    return this.getNumberOfCandidates().pipe(\r\n      map(offices => offices[office])\r\n    )\r\n  }\r\n\r\n  // Mayoral Candidates\r\n  getMayors() {\r\n    return this.getAll().then(\r\n      (all: Record<string, CandidateTree>) => Promise.all(\r\n        Object.values(all[\"mayor\"].candidates).map(url => this.http.get(url).toPromise())\r\n      )\r\n    );\r\n  }\r\n\r\n  // City Attorney Candidates\r\n  getCityAttorneys() {\r\n    return this.getAll().then(\r\n      (all: Record<string, CandidateTree>) => Promise.all(\r\n        Object.values(all[\"city-attorney\"].candidates).map(url => this.http.get(url).toPromise())\r\n      )\r\n    );\r\n  }\r\n\r\n  // City Council Candidates\r\n  getCityCouncilorsByDistrict(districtNumber: string) {\r\n    let districtName = `city-council-district-${districtNumber}`;\r\n\r\n    return this.getAll().then(\r\n      (all: Record<string, CandidateTree>) => Promise.all(\r\n        Object.values(all[districtName].candidates).map(url => this.http.get(url).toPromise())\r\n      )\r\n    );\r\n  }\r\n\r\n  getLastUpdated(): Observable<any> {\r\n    const campaignTotalsFilePath = \"assets/candidates/2020/campaign_race_totals.json\";\r\n\r\n    const lastUpdate = this.http.get<any>(campaignTotalsFilePath)\r\n      .pipe( // transform the property names used from those in the json file\r\n        map(result => result[\"last update\"])\r\n      );\r\n\r\n    return lastUpdate;\r\n  }\r\n}\r\n",
+            "constructorObj": {
+                "name": "constructor",
+                "description": "",
+                "args": [
+                    {
+                        "name": "http",
+                        "type": "HttpClient"
+                    }
+                ],
+                "line": 10,
+                "jsdoctags": [
+                    {
+                        "name": "http",
+                        "type": "HttpClient",
+                        "tagName": {
+                            "text": "param"
+                        }
+                    }
+                ]
+            },
+            "type": "injectable"
+        },
+        {
+            "name": "SidenavService",
+            "id": "injectable-SidenavService-26112954d9766ad0de48381817f05b9d",
+            "file": "src/app/services/sidenav.service.ts",
+            "properties": [
+                {
+                    "name": "candidateKeyEmittedFromSidenav$",
+                    "defaultValue": "this.emitCandidateKeyFromSidenav.asObservable()",
+                    "type": "",
+                    "optional": false,
+                    "description": "",
+                    "line": 12
+                },
+                {
+                    "name": "candidateNameEmittedFromCard$",
+                    "defaultValue": "this.emitCandidateNameFromCard.asObservable()",
+                    "type": "",
+                    "optional": false,
+                    "description": "",
+                    "line": 13
+                },
+                {
+                    "name": "candidateTypeEmittedFromSplash$",
+                    "defaultValue": "this.emitCandidateTypeFromSplash.asObservable()",
+                    "type": "",
+                    "optional": false,
+                    "description": "",
+                    "line": 14
+                },
+                {
+                    "name": "emitCandidateKeyFromSidenav",
+                    "defaultValue": "new Subject<any>()",
+                    "type": "",
+                    "optional": false,
+                    "description": "",
+                    "line": 8
+                },
+                {
+                    "name": "emitCandidateNameFromCard",
+                    "defaultValue": "new Subject<any>()",
+                    "type": "",
+                    "optional": false,
+                    "description": "",
+                    "line": 9
+                },
+                {
+                    "name": "emitCandidateTypeFromSplash",
+                    "defaultValue": "new Subject<any>()",
+                    "type": "",
+                    "optional": false,
+                    "description": "",
+                    "line": 10
+                }
+            ],
+            "methods": [
+                {
+                    "name": "emitCandidateKeySidenav",
+                    "args": [
+                        {
+                            "name": "key",
+                            "type": "string"
+                        }
+                    ],
+                    "optional": false,
+                    "returnType": "void",
+                    "typeParameters": [],
+                    "line": 18,
+                    "jsdoctags": [
+                        {
+                            "name": "key",
+                            "type": "string",
+                            "tagName": {
+                                "text": "param"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "name": "emitCandidateNameCard",
+                    "args": [
+                        {
+                            "name": "key",
+                            "type": "string"
+                        }
+                    ],
+                    "optional": false,
+                    "returnType": "void",
+                    "typeParameters": [],
+                    "line": 22,
+                    "jsdoctags": [
+                        {
+                            "name": "key",
+                            "type": "string",
+                            "tagName": {
+                                "text": "param"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "name": "emitCandidateTypeSplash",
+                    "args": [
+                        {
+                            "name": "key",
+                            "type": "string"
+                        }
+                    ],
+                    "optional": false,
+                    "returnType": "void",
+                    "typeParameters": [],
+                    "line": 26,
+                    "jsdoctags": [
+                        {
+                            "name": "key",
+                            "type": "string",
+                            "tagName": {
+                                "text": "param"
+                            }
+                        }
+                    ]
+                }
+            ],
+            "description": "",
+            "sourceCode": "import { Injectable } from '@angular/core';\r\nimport { Subject } from 'rxjs';\r\n\r\n@Injectable({\r\n  providedIn: 'root'\r\n})\r\nexport class SidenavService {\r\n  emitCandidateKeyFromSidenav = new Subject<any>();\r\n  emitCandidateNameFromCard = new Subject<any>();\r\n  emitCandidateTypeFromSplash = new Subject<any>();\r\n\r\n  candidateKeyEmittedFromSidenav$ = this.emitCandidateKeyFromSidenav.asObservable();\r\n  candidateNameEmittedFromCard$ = this.emitCandidateNameFromCard.asObservable();\r\n  candidateTypeEmittedFromSplash$ = this.emitCandidateTypeFromSplash.asObservable();\r\n\r\n  constructor() { }\r\n\r\n  emitCandidateKeySidenav(key: string) {\r\n    this.emitCandidateKeyFromSidenav.next(key);\r\n  }\r\n\r\n  emitCandidateNameCard(key: string) {\r\n    this.emitCandidateNameFromCard.next(key);\r\n  }\r\n\r\n  emitCandidateTypeSplash(key: string) {\r\n    this.emitCandidateTypeFromSplash.next(key);\r\n  }\r\n}\r\n",
+            "constructorObj": {
+                "name": "constructor",
+                "description": "",
+                "args": [],
+                "line": 14
+            },
+            "type": "injectable"
+        }
+    ],
+    "classes": [
+        {
+            "name": "AppPage",
+            "id": "class-AppPage-b37de36ad1c2262e6765c9da49016e22",
+            "file": "e2e/src/app.po.ts",
+            "type": "class",
+            "sourceCode": "import { browser, by, element } from 'protractor';\r\n\r\nexport class AppPage {\r\n  navigateTo() {\r\n    return browser.get(browser.baseUrl) as Promise<any>;\r\n  }\r\n\r\n  getTitleText() {\r\n    return element(by.css('app-root h1')).getText() as Promise<string>;\r\n  }\r\n}\r\n",
+            "properties": [],
+            "methods": [
+                {
+                    "name": "getTitleText",
+                    "args": [],
+                    "optional": false,
+                    "returnType": "any",
+                    "typeParameters": [],
+                    "line": 8
+                },
+                {
+                    "name": "navigateTo",
+                    "args": [],
+                    "optional": false,
+                    "returnType": "any",
+                    "typeParameters": [],
+                    "line": 4
+                }
+            ],
+            "indexSignatures": [],
+            "inputsClass": [],
+            "outputsClass": [],
+            "hostBindings": [],
+            "hostListeners": []
+        }
+    ],
+    "directives": [],
+    "components": [
+        {
+            "name": "AboutComponent",
+            "id": "component-AboutComponent-cffad1970b8f0f82bb2bb9dfa6bd6390",
+            "file": "src/app/components/about/about.component.ts",
+            "encapsulation": [],
+            "entryComponents": [],
+            "inputs": [],
+            "outputs": [],
+            "providers": [],
+            "selector": "app-about",
+            "styleUrls": [
+                "./about.component.scss"
+            ],
+            "styles": [],
+            "templateUrl": [
+                "./about.component.html"
+            ],
+            "viewProviders": [],
+            "inputsClass": [],
+            "outputsClass": [],
+            "propertiesClass": [],
+            "methodsClass": [
+                {
+                    "name": "ngOnInit",
+                    "args": [],
+                    "optional": false,
+                    "returnType": "void",
+                    "typeParameters": [],
+                    "line": 12
+                }
+            ],
+            "hostBindings": [],
+            "hostListeners": [],
+            "description": "",
+            "rawdescription": "",
+            "type": "component",
+            "sourceCode": "import { Component, OnInit } from '@angular/core';\r\n\r\n@Component({\r\n  selector: 'app-about',\r\n  templateUrl: './about.component.html',\r\n  styleUrls: ['./about.component.scss']\r\n})\r\nexport class AboutComponent implements OnInit {\r\n\r\n  constructor() { }\r\n\r\n  ngOnInit() {\r\n  }\r\n\r\n}\r\n",
+            "assetsDirs": [],
+            "styleUrlsData": [
+                {
+                    "data": "@import \"../../styles/variables\";\r\n@import \"../../styles/elements\";\r\n@import \"../../styles/global\";\r\n@import \"~@fortawesome/fontawesome-free/css/all.min.css\";\r\n\r\n.about_container{\r\n    padding:20px 40px 0px 30px;\r\n}\r\n.about{\r\n    margin: 20px auto 20px auto;\r\n    text-align:center;\r\n    padding:40px 40px 40px 40px;\r\n    font-weight: 100;\r\n    box-shadow: $vvshadow;\r\n    color:#4E4E4E;\r\n    background-color: #fff;\r\n    h1{\r\n      margin: 0px;\r\n    }\r\n    p{\r\n      margin:10px 0px 20px 0px;\r\n      line-height: 1.4;\r\n    }\r\n    .about_caption{\r\n        max-width: 650px;\r\n        margin-left: auto;\r\n        margin-right: auto;\r\n    }\r\n\r\n    .orgs{\r\n        display: grid;\r\n        grid-template-columns: 1fr 1fr;\r\n        column-gap: 40px;\r\n        margin: 40px auto 40px auto;\r\n        max-width: 870px;\r\n        row-gap: 20px;\r\n        a{\r\n            font-weight: bold;\r\n        }\r\n        p{ \r\n            font-size: 14px;\r\n        }\r\n        img{\r\n            margin-bottom: 20px;\r\n            margin-top: 20px;\r\n            max-width: 100%;\r\n        }\r\n    }\r\n\r\n    .transparent{\r\n        display:grid;\r\n        grid-template-columns: 1fr 425px;\r\n        padding:0px;\r\n\r\n        .transparent_copy{\r\n\r\n            text-align: left;\r\n            align-self: center;\r\n            \r\n        }\r\n\r\n        h1{\r\n            text-align: left !important;\r\n            align-self: center;\r\n        }\r\n\r\n        .transparent_photo{\r\n            align-self: end;\r\n            justify-self: end;\r\n            img{\r\n                transform: translate(40px,45px);\r\n            }\r\n        }\r\n        .transparent_photo_mobile{\r\n            display: none;\r\n            visibility: hidden;\r\n        }\r\n    }\r\n\r\n   \r\n    \r\n\r\n\r\n    @media only screen and (max-width: 1000px) {\r\n        .orgs{\r\n            grid-template-columns: 1fr !important;\r\n            max-width: 600px;\r\n        }\r\n        .transparent{\r\n     \r\n            grid-template-columns: 1fr;\r\n\r\n            .transparent_copy{\r\n\r\n                text-align: center;\r\n                \r\n            }\r\n            \r\n            .transparent_photo{\r\n                display: none;\r\n                visibility: hidden;\r\n            }\r\n            .transparent_photo_mobile{\r\n                display: inherit;\r\n                visibility: visible;\r\n                align-self: center;\r\n                justify-self: center;\r\n                img{\r\n                    transform: translate(0px,40px);\r\n                    max-height: 400px;\r\n                    width:auto;\r\n                    max-width: 100%;\r\n                }\r\n\r\n            }\r\n\r\n            h1{\r\n                text-align: center !important;\r\n            }\r\n        }\r\n    }\r\n}",
+                    "styleUrl": "./about.component.scss"
+                }
+            ],
+            "stylesData": "",
+            "constructorObj": {
+                "name": "constructor",
+                "description": "",
+                "args": [],
+                "line": 8
+            },
+            "implements": [
+                "OnInit"
+            ],
+            "templateData": "<div class=\"about_container\">\r\n  <div class=\"about\">\r\n    <h1>About Us</h1>\r\n    <p class=\"about_caption\">We are a coalition of non-partisan organizations working together to create transparency for campaign contributions and expenditures with local San Diego candidates.\r\n    </p>\r\n    <div class=\"orgs\">\r\n        <div>\r\n          <a href=\"https://opensandiego.org/\"><img src=\"../../../assets/about/osd.svg\" width=\"auto\" height=\"50\" alt=\"Open San Diego\"/></a>\r\n          <p><a href=\"https://opensandiego.org/\">Open San Diego</a> is a group of San Diegans who believe data and technology can better serve citizens, sparking a more vibrant democracy and civic life. We are a brigade of the national, non-partisan Code for America, leveraging their resources, but keenly focused on our improving local issues here at home.</p>\r\n        </div>\r\n        <div>\r\n          <a href=\"https://represent.us/\"><img src=\"../../../assets/about/repus.svg\" width=\"auto\" height=\"50\"  alt=\"Represent Us\"/></a>\r\n          <p><a href=\"https://represent.us/\">RepresentUs</a> brings together conservatives, progressives, and everyone in between to pass powerful anti-corruption laws that stop political bribery, end secret money, and fix our broken elections.</p>\r\n        </div>\r\n        <div>\r\n          <a href=\"https://www.lwv.org/\"><img src=\"../../../assets/about/lwv.svg\" width=\"auto\" height=\"50\" alt=\"The League of Women Voters\"/></a>\r\n          <p><a href=\"https://www.lwv.org/\">The League of Women Voters</a> challenges all efforts and tactics that threaten our democracy and limit the ability of voters to exercise their right to vote.</p>\r\n        </div>\r\n        <div>\r\n          <a href=\"https://www.commoncause.org/\"><img src=\"../../../assets/about/commoncause.svg\" width=\"auto\" height=\"50\"  alt=\"Common Cause\"/></a>\r\n          <p><a href=\"https://www.commoncause.org/\">Common Cause</a> is made up of more than 1 million powerful, fearless, ordinary Americans working together to build a democracy that works for us all.</p>\r\n        </div>\r\n    </div>\r\n    <div class=\"transparent\">\r\n      <div class=\"transparent_copy\">\r\n        <h1>We Fight for Transparency</h1>\r\n        <p>Currently, campaign finance information for candidates running for local offices as well as money spent by outside groups to support or defeat them is not readily accessible to the public. When the amount of money being spent as well as the source is not known, voters feel disenfranchised by the election process. Making campaign finance data easy to find and read will increase public trust and confidence in the election process.</p>\r\n     </div>\r\n     <div class=\"transparent_photo\">\r\n      <img src=\"../../../assets/about/VV_FooterBG-AboutUs.png\" width=\"100%\" height=\"auto\" alt=\"Voter\"/>\r\n     </div>\r\n     <div class=\"transparent_photo_mobile\">\r\n      <img src=\"../../../assets/about/VV_FooterBG-AboutUs-Mobile.png\" width=\"auto\" height=\"auto\" alt=\"Voter\"/>\r\n     </div>\r\n    </div>\r\n  </div>\r\n</div>\r\n"
+        },
+        {
+            "name": "AppComponent",
+            "id": "component-AppComponent-ed70cef04d923be5933c6b1146af4bf0",
+            "file": "src/app/app.component.ts",
+            "encapsulation": [],
+            "entryComponents": [],
+            "inputs": [],
+            "outputs": [],
+            "providers": [],
+            "selector": "app-root",
+            "styleUrls": [
+                "./app.component.scss"
+            ],
+            "styles": [],
+            "templateUrl": [
+                "./app.component.html"
+            ],
+            "viewProviders": [],
+            "inputsClass": [],
+            "outputsClass": [],
+            "propertiesClass": [
+                {
+                    "name": "title",
+                    "defaultValue": "'sdvv-frontend'",
+                    "type": "string",
+                    "optional": false,
+                    "description": "",
+                    "line": 9
+                }
+            ],
+            "methodsClass": [],
+            "hostBindings": [],
+            "hostListeners": [],
+            "description": "",
+            "rawdescription": "",
+            "type": "component",
+            "sourceCode": "import { Component } from '@angular/core';\r\n\r\n@Component({\r\n  selector: 'app-root',\r\n  templateUrl: './app.component.html',\r\n  styleUrls: ['./app.component.scss']\r\n})\r\nexport class AppComponent {\r\n  title = 'sdvv-frontend';\r\n}\r\n",
+            "assetsDirs": [],
+            "styleUrlsData": [
+                {
+                    "data": "",
+                    "styleUrl": "./app.component.scss"
+                }
+            ],
+            "stylesData": "",
+            "templateData": "<app-home></app-home>"
+        },
+        {
+            "name": "CandidateCardComponent",
+            "id": "component-CandidateCardComponent-4f939e1df248d5601918a8a85c428750",
+            "file": "src/app/components/candidate-card/candidate-card.component.ts",
+            "encapsulation": [],
+            "entryComponents": [],
+            "inputs": [],
+            "outputs": [],
+            "providers": [],
+            "selector": "app-candidate-card",
+            "styleUrls": [
+                "./candidate-card.component.scss"
+            ],
+            "styles": [],
+            "templateUrl": [
+                "./candidate-card.component.html"
+            ],
+            "viewProviders": [],
+            "inputsClass": [
+                {
+                    "name": "candidate",
+                    "line": 11,
+                    "type": "any"
+                },
+                {
+                    "name": "candidateImg",
+                    "line": 12,
+                    "type": "string"
+                }
+            ],
+            "outputsClass": [
+                {
+                    "name": "emitCandidateData",
+                    "defaultValue": "new EventEmitter<any>()",
+                    "line": 13,
+                    "type": "EventEmitter"
+                },
+                {
+                    "name": "emitCandidateImage",
+                    "defaultValue": "new EventEmitter<any>()",
+                    "line": 14,
+                    "type": "EventEmitter"
+                }
+            ],
+            "propertiesClass": [],
+            "methodsClass": [
+                {
+                    "name": "ngOnInit",
+                    "args": [],
+                    "optional": false,
+                    "returnType": "void",
+                    "typeParameters": [],
+                    "line": 24
+                },
+                {
+                    "name": "outputCandidateData",
+                    "args": [],
+                    "optional": false,
+                    "returnType": "void",
+                    "typeParameters": [],
+                    "line": 27
+                }
+            ],
+            "hostBindings": [],
+            "hostListeners": [],
+            "description": "",
+            "rawdescription": "",
+            "type": "component",
+            "sourceCode": "import { Component, OnInit, Input, Output, EventEmitter } from '@angular/core';\r\nimport { SidenavService } from '../../services';\r\n\r\n@Component({\r\n  selector: 'app-candidate-card',\r\n  templateUrl: './candidate-card.component.html',\r\n  styleUrls: ['./candidate-card.component.scss']\r\n})\r\n\r\nexport class CandidateCardComponent implements OnInit {\r\n  @Input() candidate: any;\r\n  @Input() candidateImg: string;\r\n  @Output() private emitCandidateData = new EventEmitter<any>();\r\n  @Output() private emitCandidateImage = new EventEmitter<any>();\r\n\r\n  constructor(private sidenavService: SidenavService) {\r\n    sidenavService.candidateKeyEmittedFromSidenav$.subscribe(res => {\r\n      if (res === this.candidate['candidate name']) {\r\n        this.outputCandidateData();\r\n      }\r\n    });\r\n  }\r\n\r\n  ngOnInit() {\r\n  }\r\n\r\n  outputCandidateData() {\r\n    this.emitCandidateData.emit(this.candidate);\r\n    this.emitCandidateImage.emit(this.candidateImg);\r\n    this.sidenavService.emitCandidateNameCard(this.candidate['candidate name']);\r\n  }\r\n}\r\n",
+            "assetsDirs": [],
+            "styleUrlsData": [
+                {
+                    "data": "@import \"../../styles/variables\";\r\n@import \"../../styles/elements\";\r\n@import \"~@fortawesome/fontawesome-free/css/all.min.css\";\r\n\r\n.candidate {\r\n    display: flex;\r\n    flex-direction: column;\r\n    align-items: center;\r\n    .candidate-image-container {\r\n        height: 125px;\r\n        width: 125px;\r\n    }\r\n    .candidate-image {\r\n        display: flex;\r\n        height: 125px;\r\n        width: 125px;\r\n        border-radius: 50%;\r\n        overflow: hidden;\r\n        border: 1px solid $vvbackground;\r\n        \r\n        img {\r\n            object-fit: cover;\r\n            object-position: center top;\r\n            width: 100%;\r\n            height: auto;\r\n            background-color: $vvbackground;\r\n        }\r\n    }\r\n}\r\n\r\n.candidate-card {\r\n    text-align: center;\r\n    height: 320px;\r\n    margin: 10px;\r\n    padding: 15px 25px 15px 25px;\r\n    background: #fff;\r\n    box-shadow: $vvshadow;\r\n    width: 180px !important;\r\n    h1 {\r\n        font-size: 20px;\r\n        color: $vvdarkblue;\r\n    }\r\n    h2 {\r\n        font-weight: normal;\r\n        font-size: 12px;\r\n        color: $vvgrey;\r\n        margin: 5px 0px 10px 0px;\r\n    }\r\n    h3 {\r\n        font-size: 18px;\r\n        color: $vvdarkgrey;\r\n    }\r\n    .first{\r\n        margin-top:10px;\r\n    }\r\n\r\n    .candidate-numbers {\r\n        display: flex;\r\n        justify-content: space-between;\r\n        margin-bottom:10px;\r\n        div {\r\n            padding: 0 6px;\r\n            h2, h3{\r\n                margin: 1px 0;\r\n            }\r\n        }\r\n        .raised h3 {\r\n            color: $vvgreen;\r\n        }\r\n    } \r\n    .candidate-button {\r\n        @include button-styles;\r\n        padding: 0 16px;\r\n        \r\n    }\r\n    .candidate-button:hover {\r\n        background-color: $vvlightblue;\r\n        text-decoration: none;\r\n    }\r\n}\r\n",
+                    "styleUrl": "./candidate-card.component.scss"
+                }
+            ],
+            "stylesData": "",
+            "constructorObj": {
+                "name": "constructor",
+                "description": "",
+                "args": [
+                    {
+                        "name": "sidenavService",
+                        "type": "SidenavService"
+                    }
+                ],
+                "line": 14,
+                "jsdoctags": [
+                    {
+                        "name": "sidenavService",
+                        "type": "SidenavService",
+                        "tagName": {
+                            "text": "param"
+                        }
+                    }
+                ]
+            },
+            "implements": [
+                "OnInit"
+            ],
+            "templateData": "<div class=\"candidate-card p-grid p-justify-center p-align-center p-nogutter\">\r\n\r\n  <div class=\"candidate p-col-12\">\r\n    <div class=\"candidate-image-container\">\r\n      <div class=\"candidate-image\">\r\n        <img [src]=\"candidateImg\" [alt]=\"candidate['candidate name']\" onError=\"this.src='../../../assets/candidate-card/profile.png'\">\r\n      </div>\r\n    </div>\r\n\r\n    <h1 class=\"first\">{{candidate.first}}</h1>\r\n    <h1>{{candidate.last}}</h1>\r\n    <h2>{{candidate.description}}</h2>\r\n  </div>\r\n\r\n  <div class=\"candidate-numbers\">\r\n    <div class=\"raised\">\r\n      <h2>Raised</h2>\r\n      <h3>{{candidate[\"raised vs spent\"][0].Raised | currency : 'USD' : 'symbol' : '1.0-0'}}</h3>\r\n    </div>\r\n\r\n    <div class=\"donors\">\r\n      <h2>Donors</h2>\r\n      <h3>{{candidate[\"raised vs spent\"][0].Donors}}</h3>\r\n    </div>\r\n  </div>\r\n\r\n  <button class=\"candidate-button\" mat-flat-button (click)=\"outputCandidateData()\">See Details</button>\r\n\r\n</div>\r\n"
+        },
+        {
+            "name": "CandidateCardExpandedComponent",
+            "id": "component-CandidateCardExpandedComponent-33f2ad1d006176d734e4d5dc771e875e",
+            "file": "src/app/components/candidate-card-expanded/candidate-card-expanded.component.ts",
+            "encapsulation": [],
+            "entryComponents": [],
+            "inputs": [],
+            "outputs": [],
+            "providers": [],
+            "selector": "app-candidate-card-expanded",
+            "styleUrls": [
+                "./candidate-card-expanded.component.scss"
+            ],
+            "styles": [],
+            "templateUrl": [
+                "./candidate-card-expanded.component.html"
+            ],
+            "viewProviders": [],
+            "inputsClass": [
+                {
+                    "name": "candidate",
+                    "line": 274,
+                    "type": ""
+                },
+                {
+                    "name": "candidateImg",
+                    "line": 22,
+                    "type": "string"
+                }
+            ],
+            "outputsClass": [
+                {
+                    "name": "isExpanded",
+                    "defaultValue": "new EventEmitter<boolean>()",
+                    "line": 23,
+                    "type": "EventEmitter"
+                }
+            ],
+            "propertiesClass": [
+                {
+                    "name": "_c",
+                    "type": "Candidate",
+                    "optional": false,
+                    "description": "",
+                    "line": 25,
+                    "modifierKind": [
+                        112
+                    ]
+                },
+                {
+                    "name": "barChartData",
+                    "defaultValue": "[\r\n    {\r\n      data: [150000],\r\n      label: 'Raised',\r\n      barPercentage: 0.4,\r\n      categoryPercentage: 1.0,\r\n      backgroundColor: 'rgba(40, 154, 88, 0.8)',\r\n      borderColor: 'rgba(40, 154, 88, 1)',\r\n      borderWidth:1,\r\n      hoverBackgroundColor:'rgba(40, 154, 88, 1)',\r\n      hoverBorderColor:'rgba(40, 154, 88, 1)',\r\n\r\n    },\r\n    {\r\n      data: [150000],\r\n      label: 'Spent',\r\n      barPercentage: 0.4,\r\n      categoryPercentage: 1.0,\r\n      backgroundColor: 'rgba(255, 44, 25, 0.8)',\r\n      borderColor: 'rgba(255, 44, 25, 1)',\r\n      borderWidth:1,\r\n      hoverBackgroundColor:'rgba(255, 44, 25, 1)',\r\n      hoverBorderColor:'rgba(255, 44, 25, 1)',\r\n    },\r\n  ]",
+                    "type": "ChartDataSets[]",
+                    "optional": false,
+                    "description": "",
+                    "line": 36
+                },
+                {
+                    "name": "barChartOptions",
+                    "defaultValue": "{\r\n    responsive: true,\r\n    maintainAspectRatio: false,\r\n    \r\n\r\n    title: {\r\n      display: true,\r\n      fontSize: 15,\r\n      fontColor: '#16375d',\r\n      fontStyle: 'bold',\r\n    },\r\n\r\n    legend: {\r\n      display: false,\r\n    },\r\n\r\n    tooltips: {\r\n      enabled: false,\r\n    },\r\n\r\n    plugins: {\r\n      datalabels: {\r\n        anchor: 'end',\r\n        align: 'end',\r\n        textAlign: 'center',\r\n        color: '#4e4e4e',\r\n        \r\n\r\n        font: {\r\n          size: 16,\r\n          weight: 'bold',\r\n        },\r\n        \r\n\r\n        formatter: (val, ctx) => {\r\n          return ctx.dataset.label === 'Raised' ? `Raised\\n$${this.mNumberFormatter(val)}` : `Spent\\n$${this.mNumberFormatter(val)}`;\r\n        },\r\n      },\r\n    },\r\n\r\n    scales: {\r\n      xAxes: [{\r\n        \r\n        ticks: {\r\n          min: 0,\r\n        },\r\n      }],\r\n\r\n      yAxes: [{\r\n        display: false,\r\n        ticks: {\r\n          suggestedMin: 0,\r\n          suggestedMax: 3000000\r\n        },\r\n      }],\r\n    },\r\n  }",
+                    "type": "ChartOptions",
+                    "optional": false,
+                    "description": "",
+                    "line": 64
+                },
+                {
+                    "name": "barChartType",
+                    "defaultValue": "'bar'",
+                    "type": "ChartType",
+                    "optional": false,
+                    "description": "",
+                    "line": 35
+                },
+                {
+                    "name": "chartPlugins",
+                    "defaultValue": "[pluginDataLabels]",
+                    "type": "[]",
+                    "optional": false,
+                    "description": "",
+                    "line": 32
+                },
+                {
+                    "name": "dataSource",
+                    "defaultValue": "new MatTableDataSource()",
+                    "type": "",
+                    "optional": false,
+                    "description": "",
+                    "line": 29
+                },
+                {
+                    "name": "displayedColumns",
+                    "type": "string[]",
+                    "optional": false,
+                    "description": "",
+                    "line": 28
+                },
+                {
+                    "name": "doughnutChartColors",
+                    "defaultValue": "[\r\n    { backgroundColor: ['#3392ff', '#bfd63b'] },\r\n  ]",
+                    "type": "Color[]",
+                    "optional": false,
+                    "description": "",
+                    "line": 131
+                },
+                {
+                    "name": "doughnutChartData",
+                    "defaultValue": "[\r\n    {\r\n      data: [5000, 1200],\r\n      \r\n    }\r\n  ]",
+                    "type": "ChartDataSets[]",
+                    "optional": false,
+                    "description": "",
+                    "line": 124
+                },
+                {
+                    "name": "doughnutChartOptions",
+                    "defaultValue": "{\r\n    responsive: true,\r\n    maintainAspectRatio: false,\r\n    cutoutPercentage:60,\r\n    animation:{animateRotate:false},\r\n\r\n    legend: {\r\n      display: false,\r\n    },\r\n\r\n    tooltips: {\r\n      enabled: false,\r\n    },\r\n\r\n    plugins: {\r\n      datalabels: {\r\n        anchor: 'start',\r\n        align: 'start',\r\n        color: '#4e4e4e',\r\n        textAlign:'center',\r\n\r\n        font: {\r\n          size: 16,\r\n          weight: 'bold',\r\n          \r\n        },\r\n\r\n        formatter: (val, ctx) => {\r\n          return ctx.dataIndex === 0 ? `In\\n$${this.mNumberFormatter(val)}` : `Out\\n$${this.mNumberFormatter(val)}`;\r\n        },\r\n      },\r\n    },\r\n  }",
+                    "type": "any",
+                    "optional": false,
+                    "description": "",
+                    "line": 135
+                },
+                {
+                    "name": "doughnutChartType",
+                    "defaultValue": "'doughnut'",
+                    "type": "ChartType",
+                    "optional": false,
+                    "description": "",
+                    "line": 123
+                },
+                {
+                    "name": "stackedHorizontalBarChartData",
+                    "defaultValue": "[\r\n    {\r\n      data: [200000],\r\n      barPercentage: 0.4,\r\n      categoryPercentage: 1.0,\r\n      backgroundColor: 'rgba(0, 119, 255, 0.8)',\r\n      borderColor: 'rgba(0, 119, 255, 1)',\r\n      borderWidth:1,\r\n      hoverBackgroundColor:'rgba(0, 119, 255, 1)',\r\n      hoverBorderColor:'rgba(0, 119, 255, 1)',\r\n\r\n      datalabels: {\r\n        anchor: 'end',\r\n        align: 'end',\r\n        textAlign: 'left',\r\n        color: '#ffffff',\r\n\r\n\r\n        font: {\r\n          size: 16,\r\n          weight: 'bold',\r\n        },\r\n        \r\n        formatter: (val) => `Support\\n$${this.mNumberFormatter(val)}`,\r\n      },\r\n    },\r\n\r\n    {\r\n      data: [5000],\r\n      barPercentage: 0.4,\r\n      categoryPercentage: 1.0,\r\n      backgroundColor: 'rgba(255, 113, 25, 0.8)',\r\n      borderColor: 'rgba(255, 113, 25, 1)',\r\n      borderWidth:1,\r\n      hoverBackgroundColor:'rgba(255, 113, 25, 1)',\r\n      hoverBorderColor:'rgba(255, 113, 25, 1)',\r\n\r\n      datalabels: {\r\n        anchor: 'end',\r\n        align: 'end',\r\n        textAlign: 'left',\r\n        color: '#ffffff',\r\n\r\n        font: {\r\n          size: 16,\r\n          weight: 'bold',\r\n        },\r\n\r\n        formatter: (val) => `Oppose\\n$${this.mNumberFormatter(val)}`,\r\n      },\r\n    },\r\n   \r\n  ]",
+                    "type": "ChartDataSets[]",
+                    "optional": false,
+                    "description": "",
+                    "line": 171
+                },
+                {
+                    "name": "stackedHorizontalBarChartOptions",
+                    "defaultValue": "{\r\n    responsive: true,\r\n    maintainAspectRatio: false,\r\n\r\n    layout: {\r\n      padding: {\r\n        left: 0,\r\n        right: 20,\r\n      },\r\n    },\r\n\r\n    legend: {\r\n      display: false,\r\n    },\r\n\r\n    tooltips: {\r\n      enabled: false,\r\n    },\r\n\r\n    scales: {\r\n      xAxes: [{\r\n        display: false,\r\n        \r\n        ticks: {\r\n          suggestedMin: 0,\r\n          suggestedMax: 900000\r\n        }\r\n      }],\r\n\r\n      yAxes: [{\r\n        display: false,\r\n        gridLines: {\r\n          color: \"#727272\",\r\n        },\r\n        ticks: {\r\n          min: 0,\r\n        }\r\n\r\n      }],\r\n    },\r\n  }",
+                    "type": "ChartOptions",
+                    "optional": false,
+                    "description": "",
+                    "line": 226
+                },
+                {
+                    "name": "stackedHorizontalBarChartType",
+                    "defaultValue": "'horizontalBar'",
+                    "type": "ChartType",
+                    "optional": false,
+                    "description": "",
+                    "line": 170
+                }
+            ],
+            "methodsClass": [
+                {
+                    "name": "close",
+                    "args": [],
+                    "optional": false,
+                    "returnType": "void",
+                    "typeParameters": [],
+                    "line": 369
+                },
+                {
+                    "name": "commaNumberFormatter",
+                    "args": [
+                        {
+                            "name": "num",
+                            "type": "number"
+                        }
+                    ],
+                    "optional": false,
+                    "returnType": "any",
+                    "typeParameters": [],
+                    "line": 365,
+                    "jsdoctags": [
+                        {
+                            "name": "num",
+                            "type": "number",
+                            "tagName": {
+                                "text": "param"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "name": "ConvertToInt",
+                    "args": [
+                        {
+                            "name": "val",
+                            "type": ""
+                        }
+                    ],
+                    "optional": false,
+                    "returnType": "any",
+                    "typeParameters": [],
+                    "line": 374,
+                    "jsdoctags": [
+                        {
+                            "name": "val",
+                            "type": "",
+                            "tagName": {
+                                "text": "param"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "name": "currencyToNumber",
+                    "args": [
+                        {
+                            "name": "currencyString",
+                            "type": "string"
+                        }
+                    ],
+                    "optional": false,
+                    "returnType": "any",
+                    "typeParameters": [],
+                    "line": 355,
+                    "jsdoctags": [
+                        {
+                            "name": "currencyString",
+                            "type": "string",
+                            "tagName": {
+                                "text": "param"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "name": "mNumberFormatter",
+                    "args": [
+                        {
+                            "name": "num",
+                            "type": "number"
+                        }
+                    ],
+                    "optional": false,
+                    "returnType": "any",
+                    "typeParameters": [],
+                    "line": 360,
+                    "jsdoctags": [
+                        {
+                            "name": "num",
+                            "type": "number",
+                            "tagName": {
+                                "text": "param"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "name": "setChartsData",
+                    "args": [
+                        {
+                            "name": "c",
+                            "type": "Candidate"
+                        }
+                    ],
+                    "optional": false,
+                    "returnType": "void",
+                    "typeParameters": [],
+                    "line": 330,
+                    "jsdoctags": [
+                        {
+                            "name": "c",
+                            "type": "Candidate",
+                            "tagName": {
+                                "text": "param"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "name": "setDisplayedColumns",
+                    "args": [],
+                    "optional": false,
+                    "returnType": "void",
+                    "typeParameters": [],
+                    "line": 283
+                },
+                {
+                    "name": "setTableData",
+                    "args": [
+                        {
+                            "name": "c",
+                            "type": "Candidate"
+                        }
+                    ],
+                    "optional": false,
+                    "returnType": "void",
+                    "typeParameters": [],
+                    "line": 292,
+                    "jsdoctags": [
+                        {
+                            "name": "c",
+                            "type": "Candidate",
+                            "tagName": {
+                                "text": "param"
+                            }
+                        }
+                    ]
+                }
+            ],
+            "hostBindings": [],
+            "hostListeners": [],
+            "description": "",
+            "rawdescription": "",
+            "type": "component",
+            "sourceCode": "import * as pluginDataLabels from 'chartjs-plugin-datalabels';\r\nimport { Component, Input, Output, EventEmitter } from '@angular/core';\r\nimport { ChartOptions, ChartType, ChartDataSets } from 'chart.js';\r\nimport { Candidate } from '../../candidate';\r\nimport { Color } from 'ng2-charts';\r\nimport { MatTableDataSource } from '@angular/material/table';\r\n\r\nconst placeholder_data = [\r\n  { colorCode: '#007431', industry: 'Technology', amount: 200000, percentage: 0.5 },\r\n  { colorCode: '#00903d', industry: 'Finance', amount: 200000, percentage: 0.2 },\r\n  { colorCode: '#00af4a', industry: 'Energy', amount: 200000, percentage: null },\r\n  { colorCode: '#00d359', industry: 'Construction', amount: 200000, percentage: null },\r\n  { colorCode: '#00fc6a', industry: 'Other', amount: 200000, percentage: null },\r\n];\r\n\r\n@Component({\r\n  selector: 'app-candidate-card-expanded',\r\n  templateUrl: './candidate-card-expanded.component.html',\r\n  styleUrls: ['./candidate-card-expanded.component.scss']\r\n})\r\nexport class CandidateCardExpandedComponent {\r\n  @Input() candidateImg: string;\r\n  @Output() isExpanded = new EventEmitter<boolean>();\r\n\r\n  private _c: Candidate;\r\n\r\n  // Industry Table\r\n  displayedColumns: string[];\r\n  dataSource = new MatTableDataSource();\r\n\r\n  // All Charts\r\n  chartPlugins = [pluginDataLabels];\r\n\r\n  // Raised v. Spent Chart\r\n  barChartType: ChartType = 'bar';\r\n  barChartData: ChartDataSets[] = [\r\n    {\r\n      data: [150000],\r\n      label: 'Raised',\r\n      barPercentage: 0.4,\r\n      categoryPercentage: 1.0,\r\n      backgroundColor: 'rgba(40, 154, 88, 0.8)',\r\n      borderColor: 'rgba(40, 154, 88, 1)',\r\n      borderWidth:1,\r\n      hoverBackgroundColor:'rgba(40, 154, 88, 1)',\r\n      hoverBorderColor:'rgba(40, 154, 88, 1)',\r\n\r\n    },\r\n    {\r\n      data: [150000],\r\n      label: 'Spent',\r\n      barPercentage: 0.4,\r\n      categoryPercentage: 1.0,\r\n      backgroundColor: 'rgba(255, 44, 25, 0.8)',\r\n      borderColor: 'rgba(255, 44, 25, 1)',\r\n      borderWidth:1,\r\n      hoverBackgroundColor:'rgba(255, 44, 25, 1)',\r\n      hoverBorderColor:'rgba(255, 44, 25, 1)',\r\n    },\r\n  ];\r\n\r\n\r\n\r\n  barChartOptions: ChartOptions = {\r\n    responsive: true,\r\n    maintainAspectRatio: false,\r\n    \r\n\r\n    title: {\r\n      display: true,\r\n      fontSize: 15,\r\n      fontColor: '#16375d',\r\n      fontStyle: 'bold',\r\n    },\r\n\r\n    legend: {\r\n      display: false,\r\n    },\r\n\r\n    tooltips: {\r\n      enabled: false,\r\n    },\r\n\r\n    plugins: {\r\n      datalabels: {\r\n        anchor: 'end',\r\n        align: 'end',\r\n        textAlign: 'center',\r\n        color: '#4e4e4e',\r\n        \r\n\r\n        font: {\r\n          size: 16,\r\n          weight: 'bold',\r\n        },\r\n        \r\n\r\n        formatter: (val, ctx) => {\r\n          return ctx.dataset.label === 'Raised' ? `Raised\\n$${this.mNumberFormatter(val)}` : `Spent\\n$${this.mNumberFormatter(val)}`;\r\n        },\r\n      },\r\n    },\r\n\r\n    scales: {\r\n      xAxes: [{\r\n        \r\n        ticks: {\r\n          min: 0,\r\n        },\r\n      }],\r\n\r\n      yAxes: [{\r\n        display: false,\r\n        ticks: {\r\n          suggestedMin: 0,\r\n          suggestedMax: 3000000\r\n        },\r\n      }],\r\n    },\r\n  }\r\n\r\n  // In v. Out District\r\n  doughnutChartType: ChartType = 'doughnut';\r\n  doughnutChartData: ChartDataSets[] = [\r\n    {\r\n      data: [5000, 1200],\r\n      \r\n    }\r\n  ];\r\n\r\n  doughnutChartColors: Color[] = [\r\n    { backgroundColor: ['#3392ff', '#bfd63b'] },\r\n  ];\r\n\r\n  doughnutChartOptions: any = {\r\n    responsive: true,\r\n    maintainAspectRatio: false,\r\n    cutoutPercentage:60,\r\n    animation:{animateRotate:false},\r\n\r\n    legend: {\r\n      display: false,\r\n    },\r\n\r\n    tooltips: {\r\n      enabled: false,\r\n    },\r\n\r\n    plugins: {\r\n      datalabels: {\r\n        anchor: 'start',\r\n        align: 'start',\r\n        color: '#4e4e4e',\r\n        textAlign:'center',\r\n\r\n        font: {\r\n          size: 16,\r\n          weight: 'bold',\r\n          \r\n        },\r\n\r\n        formatter: (val, ctx) => {\r\n          return ctx.dataIndex === 0 ? `In\\n$${this.mNumberFormatter(val)}` : `Out\\n$${this.mNumberFormatter(val)}`;\r\n        },\r\n      },\r\n    },\r\n  }\r\n\r\n  // Oppose v. Support Chart\r\n  stackedHorizontalBarChartType: ChartType = 'horizontalBar';\r\n  stackedHorizontalBarChartData: ChartDataSets[] = [\r\n    {\r\n      data: [200000],\r\n      barPercentage: 0.4,\r\n      categoryPercentage: 1.0,\r\n      backgroundColor: 'rgba(0, 119, 255, 0.8)',\r\n      borderColor: 'rgba(0, 119, 255, 1)',\r\n      borderWidth:1,\r\n      hoverBackgroundColor:'rgba(0, 119, 255, 1)',\r\n      hoverBorderColor:'rgba(0, 119, 255, 1)',\r\n\r\n      datalabels: {\r\n        anchor: 'end',\r\n        align: 'end',\r\n        textAlign: 'left',\r\n        color: '#ffffff',\r\n\r\n\r\n        font: {\r\n          size: 16,\r\n          weight: 'bold',\r\n        },\r\n        \r\n        formatter: (val) => `Support\\n$${this.mNumberFormatter(val)}`,\r\n      },\r\n    },\r\n\r\n    {\r\n      data: [5000],\r\n      barPercentage: 0.4,\r\n      categoryPercentage: 1.0,\r\n      backgroundColor: 'rgba(255, 113, 25, 0.8)',\r\n      borderColor: 'rgba(255, 113, 25, 1)',\r\n      borderWidth:1,\r\n      hoverBackgroundColor:'rgba(255, 113, 25, 1)',\r\n      hoverBorderColor:'rgba(255, 113, 25, 1)',\r\n\r\n      datalabels: {\r\n        anchor: 'end',\r\n        align: 'end',\r\n        textAlign: 'left',\r\n        color: '#ffffff',\r\n\r\n        font: {\r\n          size: 16,\r\n          weight: 'bold',\r\n        },\r\n\r\n        formatter: (val) => `Oppose\\n$${this.mNumberFormatter(val)}`,\r\n      },\r\n    },\r\n   \r\n  ];\r\n\r\n\r\n  stackedHorizontalBarChartOptions: ChartOptions = {\r\n    responsive: true,\r\n    maintainAspectRatio: false,\r\n\r\n    layout: {\r\n      padding: {\r\n        left: 0,\r\n        right: 20,\r\n      },\r\n    },\r\n\r\n    legend: {\r\n      display: false,\r\n    },\r\n\r\n    tooltips: {\r\n      enabled: false,\r\n    },\r\n\r\n    scales: {\r\n      xAxes: [{\r\n        display: false,\r\n        \r\n        ticks: {\r\n          suggestedMin: 0,\r\n          suggestedMax: 900000\r\n        }\r\n      }],\r\n\r\n      yAxes: [{\r\n        display: false,\r\n        gridLines: {\r\n          color: \"#727272\",\r\n        },\r\n        ticks: {\r\n          min: 0,\r\n        }\r\n\r\n      }],\r\n    },\r\n  }\r\n\r\n  constructor() { }\r\n\r\n  get candidate() {\r\n    return this._c;\r\n  }\r\n\r\n  @Input() set candidate(c: Candidate) {\r\n    this._c = c;\r\n    // console.debug(c);\r\n    this.setChartsData(c);\r\n    this.setDisplayedColumns();\r\n    this.setTableData(c);\r\n  }\r\n\r\n  // Setting By Industry Table\r\n  setDisplayedColumns() {\r\n    this.displayedColumns = [\r\n      'colorCode',\r\n      'industry',\r\n      'amount',\r\n      'percentage',\r\n    ];\r\n  }\r\n\r\n  setTableData(c: Candidate) {\r\n    const topFiveIndustries = [\r\n      {\r\n        colorCode: '#007431',\r\n        industry: c['by industry'][0]['industry 1'][0],\r\n        amount: Number(c['by industry'][0]['industry 1'][1]),\r\n        percentage: Number(c['by industry'][0]['industry 1'][2]),\r\n      },\r\n      {\r\n        colorCode: '#00903d',\r\n        industry: c['by industry'][0]['industry 2'][0],\r\n        amount: Number(c['by industry'][0]['industry 2'][1]),\r\n        percentage: Number(c['by industry'][0]['industry 2'][2]),\r\n      },\r\n      {\r\n        colorCode: '#00af4a',\r\n        industry: c['by industry'][0]['industry 3'][0],\r\n        amount: Number(c['by industry'][0]['industry 3'][1]),\r\n        percentage: Number(c['by industry'][0]['industry 3'][2]),\r\n      },\r\n      {\r\n        colorCode: '#00d359',\r\n        industry: c['by industry'][0]['industry 4'][0],\r\n        amount: Number(c['by industry'][0]['industry 4'][1]),\r\n        percentage: Number(c['by industry'][0]['industry 4'][2]),\r\n      },\r\n      {\r\n        colorCode: '#00fc6a',\r\n        industry: c['by industry'][0]['industry 5'][0],\r\n        amount: Number(c['by industry'][0]['industry 5'][1]),\r\n        percentage: Number(c['by industry'][0]['industry 5'][2]),\r\n      },\r\n    ];\r\n\r\n    this.dataSource.data = topFiveIndustries;\r\n  }\r\n\r\n  // Setting Chart Data\r\n  setChartsData(c: Candidate) {\r\n    // Raised v. Spent\r\n    this.barChartData = [\r\n      {...this.barChartData[0], data: [this.currencyToNumber(c['raised vs spent'][0].Raised)]},\r\n      {...this.barChartData[1], data: [this.currencyToNumber(c['raised vs spent'][0].Spent)]}\r\n    ];\r\n\r\n    // In V. Out District\r\n    if (c['in vs out district']) {\r\n      this.doughnutChartData = [\r\n        {data: [\r\n          this.currencyToNumber(c['in vs out district'][0].in),\r\n          this.currencyToNumber(c['in vs out district'][0].out)\r\n        ]}\r\n      ];\r\n    }\r\n\r\n    // Oppose v. Support\r\n    this.stackedHorizontalBarChartData = [\r\n      {...this.stackedHorizontalBarChartData[0], data: [this.currencyToNumber(c['support'])]},\r\n      {...this.stackedHorizontalBarChartData[1], data: [this.currencyToNumber(c['oppose'])]}\r\n    ];\r\n  }\r\n\r\n  // Convert Currency String to Number\r\n  currencyToNumber(currencyString: string) {\r\n    return Number(currencyString.replace(/[^0-9\\.-]+/g,\"\"))\r\n  }\r\n\r\n  // Adding K At The End of Values Over 9999 (i.e. 10K, 100K)\r\n  mNumberFormatter(num: number) {\r\n    return Math.abs(num) > 1e6 ? Math.sign(num)*((Math.round(num/1e4))/100) + 'M' : this.commaNumberFormatter(Math.sign(num)*Math.abs(num));\r\n  }\r\n\r\n  // Adding Comma Separators for Values Over 999\r\n  commaNumberFormatter(num: number) {\r\n    return num.toLocaleString('en');\r\n  }\r\n\r\n  close() {\r\n    this.isExpanded.emit(false);\r\n  }\r\n  \r\n  //convert string to int\r\n  ConvertToInt(val){\r\n    return parseInt(val);\r\n  }\r\n\r\n}\r\n",
+            "assetsDirs": [],
+            "styleUrlsData": [
+                {
+                    "data": "@import \"../../styles/variables\";\r\n@import \"../../styles/elements\";\r\n@import \"~@fortawesome/fontawesome-free/css/all.min.css\";\r\n\r\n.vv-grid{\r\n    display: grid;\r\n    grid-template-columns:180px 1fr 1fr 1fr;\r\n    align-self: start;\r\n    justify-items: center;\r\n    padding:20px;\r\n    \r\n\r\n}\r\n.candidate-card-expanded {\r\n    padding: 15px 25px 15px 25px;\r\n    margin: 10px;\r\n    text-align: center;\r\n    background: #fff;\r\n    box-shadow: $vvshadow;\r\n \r\n\r\n    h1 {\r\n        font-size: 20px;\r\n        color: $vvdarkblue;\r\n    }\r\n\r\n    h2 {\r\n        font-weight: normal;\r\n        font-size: 12px;\r\n        color: $vvgrey;\r\n        margin: 5px 0px 10px 0px;\r\n    }\r\n\r\n    h3 {\r\n        font-size: 18px;\r\n        color: $vvdarkgrey;\r\n    }\r\n\r\n    i {\r\n        cursor: pointer;\r\n    }\r\n\r\n    .title {\r\n        padding: 0;\r\n        font-size: 18px;\r\n        font-weight: bold;\r\n        color: $vvdarkblue;\r\n    }\r\n\r\n    .candidate {\r\n        display: flex;\r\n        flex-direction: column;\r\n        align-items: center;\r\n        padding: 0px 0px 15px 25px;\r\n\r\n        .first{\r\n            margin-top:10px;\r\n        }\r\n      \r\n        .candidate-numbers {\r\n            display: flex;\r\n            justify-content: space-between;\r\n            margin-bottom:10px;\r\n            div {\r\n                padding: 0 6px;\r\n                h2, h3{\r\n                    margin: 1px 0;\r\n                }\r\n            }\r\n            .raised h3 {\r\n                color: $vvgreen;\r\n            }\r\n        } \r\n\r\n\r\n        \r\n        .candidate-image-container {\r\n            height: 125px;\r\n            width: 125px;\r\n        }\r\n\r\n        .candidate-image {\r\n            display: flex;\r\n            height: 125px;\r\n            width: 125px;\r\n            border-radius: 50%;\r\n            overflow: hidden;\r\n\r\n            img {\r\n  \r\n                object-fit: cover;\r\n                object-position: center top;\r\n                width: 100%;\r\n                height: auto;\r\n                background-color: #ECEFF2;\r\n            }\r\n        }\r\n    }\r\n  \r\n    .chart-container{\r\n        position: relative; \r\n        height:20vh; \r\n        width:20vw;\r\n        margin:auto;\r\n    }\r\n\r\n    .raised-spent{\r\n        .chart-container-raised{\r\n            position: relative; \r\n            height:21vh; \r\n            width:12vw;\r\n            max-height: 200px;\r\n            margin:auto;\r\n        }\r\n        .raised-spent-footer-title,.raised-spent-footer-content{\r\n            margin:5px 0px;\r\n        }\r\n    }\r\n\r\n    .industries {\r\n        .industries-table {\r\n            width: 100%;\r\n            text-align: left;\r\n        }\r\n\r\n        .mat-cell {\r\n            font-size: 13px;\r\n            color: $vvgrey;\r\n            padding:8px;\r\n        }\r\n        \r\n        .mat-cell:nth-last-child(2), .mat-cell:last-child, \r\n        .mat-header-cell:nth-last-child(2), .mat-header-cell:last-child {\r\n            text-align: right;\r\n        }\r\n\r\n        .mat-cell:last-child {\r\n            font-size: 20px;\r\n            font-weight: bold;\r\n        }\r\n    }\r\n    .outside-money{\r\n        grid-column: 1 / 5;\r\n        border:1px solid #efefef;\r\n        margin-bottom: 10px;\r\n        padding-bottom: 30px;\r\n        justify-self: stretch;\r\n        background-color: $vvdarkgrey;\r\n        color:#fff;\r\n\r\n        .title, .helper-tip, .donors, .raised{\r\n            color:#fff;\r\n            h2, h3{\r\n                color:#fff;\r\n                margin: 0px 0px 5px 0px;\r\n            }\r\n        }\r\n\r\n\r\n        .chart-container-outside{\r\n            \r\n            height:10vh; \r\n            width:58vw;\r\n            border-left:1px solid #727272;\r\n            margin-left:40px;\r\n           \r\n            \r\n        }\r\n        \r\n        .outside-grid{\r\n            display: grid;\r\n            grid-template-columns:60vw 0.8fr;\r\n            justify-self: stretch;\r\n           \r\n\r\n            .donors{\r\n                \r\n                padding:20px 0px 20px 30px;\r\n                text-align: left;\r\n                align-self: center;\r\n            }\r\n            .raised{\r\n                padding:20px 0px 20px 30px;\r\n                text-align: left;\r\n                border-left: 1px solid #727272;\r\n                align-self: center;\r\n            }\r\n        }\r\n        \r\n\r\n    }\r\n    \r\n\r\n    .helper-tip {\r\n        color: $vvgrey;\r\n        font-size: 10px;\r\n    }\r\n\r\n    .close {\r\n        position: absolute;\r\n        top: 30px;\r\n        right: 45px;\r\n    }\r\n}\r\n\r\n.website-link {\r\n    display: flex;\r\n    justify-content: center;\r\n    vertical-align: middle;\r\n    align-items: center;\r\n    margin-top: 10px;\r\n    font-size: 14px;\r\n    color: $vvlightblue;\r\n\r\n    .mat-icon {\r\n        padding-right: 5px;\r\n    }\r\n}\r\n\r\n.full-details-btn {\r\n    @include button-styles;\r\n    padding: 0 16px;\r\n}\r\n\r\n.full-details-btn:hover {\r\n    background-color: $vvlightblue;\r\n}\r\n\r\n.divider {\r\n    width: 100%;\r\n    border: 1px solid #e4e4e4;\r\n    margin: 30px 0 10px;\r\n}\r\n\r\n.remove-border {\r\n    border: none;\r\n}\r\n\r\n\r\n\r\n// Expanded Card Adjustments for Smaller Screens\r\n@media only screen and (max-width: 1200px) {\r\n   .vv-grid{\r\n    display:block !important;\r\n   }\r\n   .in-out-district{\r\n       margin-bottom:40px;\r\n   }\r\n   .chart-container{\r\n        height:20vh !important; \r\n        width:60vw !important;\r\n    }   \r\n    .chart-container-raised{\r\n        height:25vh !important; \r\n        width:60vw !important;  \r\n    }\r\n \r\n\r\n    \r\n\r\n   \r\n \r\n}\r\n\r\n::ng-deep .mat-tooltip {\r\n    font-size: 16px;\r\n}\r\n",
+                    "styleUrl": "./candidate-card-expanded.component.scss"
+                }
+            ],
+            "stylesData": "",
+            "constructorObj": {
+                "name": "constructor",
+                "description": "",
+                "args": [],
+                "line": 266
+            },
+            "accessors": {
+                "candidate": {
+                    "name": "candidate",
+                    "setSignature": {
+                        "name": "candidate",
+                        "type": "void",
+                        "args": [
+                            {
+                                "name": "c",
+                                "type": ""
+                            }
+                        ],
+                        "returnType": "void",
+                        "line": 274,
+                        "jsdoctags": [
+                            {
+                                "name": "c",
+                                "type": "",
+                                "tagName": {
+                                    "text": "param"
+                                }
+                            }
+                        ]
+                    },
+                    "getSignature": {
+                        "name": "candidate",
+                        "type": "",
+                        "returnType": "",
+                        "line": 270
+                    }
+                }
+            },
+            "templateData": "<div class=\"candidate-card-expanded vv-grid\">\r\n\r\n  <div>\r\n    <div class=\"candidate\">\r\n\r\n      <div class=\"candidate-image-container\">\r\n        <div class=\"candidate-image\">\r\n          <img [src]=\"candidateImg\" [alt]=\"candidate['candidate name']\" onError=\"this.src='../../../assets/candidate-card/profile.png'\">\r\n        </div>\r\n      </div>\r\n      <h1 class=\"first\">{{candidate['first']}}</h1>\r\n      <h1>{{candidate['last']}}</h1>\r\n      <h2>{{ candidate['description'] }}</h2>\r\n\r\n      <div class=\"candidate-numbers\">\r\n        <div class=\"raised\">\r\n          <h2>Raised</h2>\r\n          <h3>{{candidate[\"raised vs spent\"][0].Raised | currency : 'USD' : 'symbol' : '1.0-0'}}</h3>\r\n        </div>\r\n\r\n        <div class=\"donors\">\r\n          <h2>Donors</h2>\r\n          <h3>{{candidate[\"raised vs spent\"][0].Donors}}</h3>\r\n        </div>\r\n      </div>\r\n  \r\n      \r\n      <div>\r\n        <button class=\"full-details-btn\" routerLink=\"/under-construction\" mat-flat-button>See Full Details</button>\r\n      </div>\r\n      <div class=\"website-link\">\r\n        <mat-icon>link</mat-icon>\r\n        <a href=\"{{ candidate['website'] }}\">Website</a>\r\n      </div>\r\n  \r\n    </div>\r\n  </div>\r\n  <div class=\"raised-spent\">\r\n\r\n      <div class=\"title\">\r\n        <p>\r\n          Raised v. Spent\r\n          <sup>\r\n            <i\r\n              class=\"helper-tip fa fa-question-circle\"\r\n              aria-hidden=\"true\"\r\n              matTooltip=\"Total campaign funds raised and spent by the candidate.\"\r\n            >\r\n            </i>\r\n          </sup>\r\n        </p>\r\n      </div>\r\n  \r\n      <div class=\"raised-spent-chart chart-container-raised\">\r\n        <canvas baseChart\r\n          width=\"350\"\r\n          height=\"550\"\r\n          [chartType]=\"barChartType\"\r\n          [datasets]=\"barChartData\"\r\n          [options]=\"barChartOptions\"\r\n          [plugins]=\"chartPlugins\"\r\n        ></canvas>\r\n      </div>\r\n  \r\n      <div class=\"raised-spent-footer\">\r\n        <div class=\"avg-donation\">\r\n          <h2 class=\"raised-spent-footer-title\">Average Donation</h2>\r\n          <h3 class=\"raised-spent-footer-content\">{{ candidate['raised vs spent'][0]['Average Donor'] | currency:'USD':'symbol':'1.0-0' }}</h3>\r\n        </div>\r\n      </div>\r\n  </div>\r\n  <div class=\"industries\">\r\n      <div class=\"title\">\r\n        <p>\r\n          Donations by Group\r\n          <sup>\r\n            <i\r\n              class=\"helper-tip fa fa-question-circle\"\r\n              aria-hidden=\"true\"\r\n              matTooltip=\"Total contributions from the five largest groups of campaign donors.  Groups are determined by the industry segment of each donor's employer.\"\r\n            >\r\n            </i>\r\n          </sup>\r\n        </p>\r\n      </div>\r\n  \r\n\r\n\r\n    <div>\r\n      <table class=\"industries-table\" mat-table [dataSource]=\"dataSource\">\r\n        <ng-container matColumnDef=\"colorCode\">\r\n          <th mat-header-cell *matHeaderCellDef>Color Code</th>\r\n          <td [ngClass]=\"{'remove-border': i == dataSource.data.length - 1}\" mat-cell *matCellDef=\"let element; let i = index\" [style.color]=\"element.colorCode\">\r\n            <mat-icon>fiber_manual_record</mat-icon>\r\n          </td>\r\n        </ng-container>\r\n  \r\n        <ng-container matColumnDef=\"industry\">\r\n          <th mat-header-cell *matHeaderCellDef>Industry</th>\r\n          <td [ngClass]=\"{'remove-border': i == dataSource.data.length - 1}\" mat-cell *matCellDef=\"let element; let i = index\">{{ element.industry }}</td>\r\n        </ng-container>\r\n  \r\n        <ng-container matColumnDef=\"amount\">\r\n          <th mat-header-cell *matHeaderCellDef>Amount</th>\r\n          <td [ngClass]=\"{'remove-border': i == dataSource.data.length - 1}\" mat-cell *matCellDef=\"let element; let i = index\">{{ element.amount | currency:'USD':'symbol':'1.0-0' }}</td>\r\n        </ng-container>\r\n  \r\n        <ng-container matColumnDef=\"percentage\">\r\n          <th mat-header-cell *matHeaderCellDef>Percentage</th>\r\n          <td [ngClass]=\"{'remove-border': i == dataSource.data.length - 1}\" mat-cell *matCellDef=\"let element; let i = index\">{{ element.percentage | number:'1.0-0' }}%</td>\r\n        </ng-container>\r\n  \r\n        \r\n        <tr mat-row *matRowDef=\"let row; columns: displayedColumns\"></tr>\r\n      </table>\r\n    </div>\r\n  </div>\r\n\r\n\r\n  <div class=\"in-out-district\">\r\n\r\n    <div class=\"title\">\r\n      <p>\r\n        In v. Out City\r\n        <sup>\r\n          <i\r\n            class=\"helper-tip fa fa-question-circle\"\r\n            aria-hidden=\"true\"\r\n            matTooltip=\"Total campaign funds raised in the city of San Diego versus funds raised outside of city limits.\"\r\n          >\r\n          </i>\r\n        </sup>\r\n      </p>\r\n    </div>\r\n\r\n    <div class=\"chart-container\">\r\n      <canvas baseChart\r\n        width=\"260\"\r\n        height=\"260\"\r\n        [chartType]=\"doughnutChartType\"\r\n        [datasets]=\"doughnutChartData\"\r\n        [colors]=\"doughnutChartColors\"\r\n        [options]=\"doughnutChartOptions\"\r\n        [plugins]=\"chartPlugins\"\r\n      >\r\n      </canvas>\r\n    </div>\r\n  </div>\r\n\r\n\r\n  <div class=\"close\">\r\n    <i style=\"font-size: 25px;\" class=\"fa fa-times-circle\" aria-hidden=\"true\" (click)=\"close()\"></i>\r\n  </div>\r\n  \r\n\r\n\r\n  <div class=\"outside-money\">\r\n    <div class=\"title\">\r\n      <p>\r\n        Outside Money\r\n        <sup>\r\n          <i\r\n            class=\"helper-tip fa fa-question-circle\"\r\n            aria-hidden=\"true\"\r\n            matTooltip=\"Amount of money raised and spent by independent expenditure committees spent in support or opposition of a candidate but not contributed directly to their campaign.\"\r\n          >\r\n          </i>\r\n        </sup>\r\n      </p>\r\n    </div>\r\n    <div class=\"outside-grid\">\r\n      <div  class=\"chart-container-outside\">\r\n        <canvas baseChart\r\n          [chartType]=\"stackedHorizontalBarChartType\"\r\n          [datasets]=\"stackedHorizontalBarChartData\"\r\n          [options]=\"stackedHorizontalBarChartOptions\"\r\n          [plugins]=\"chartPlugins\"\r\n        ></canvas>\r\n      </div>\r\n\r\n      <div class=\"raised\">\r\n        <h2>Total Expenditures</h2>\r\n        <h3>{{(ConvertToInt(candidate['oppose'])+ConvertToInt(candidate['support']))| currency : 'USD' : 'symbol' : '1.0-0'}}</h3>\r\n      </div>\r\n    </div>\r\n  </div>\r\n\r\n"
+        },
+        {
+            "name": "CityAttorneyComponent",
+            "id": "component-CityAttorneyComponent-5a002c40deacd3ec0d301bb1a8102e8c",
+            "file": "src/app/components/city-attorney/city-attorney.component.ts",
+            "encapsulation": [],
+            "entryComponents": [],
+            "inputs": [],
+            "outputs": [],
+            "providers": [],
+            "selector": "app-city-attorney",
+            "styleUrls": [
+                "./city-attorney.component.scss"
+            ],
+            "styles": [],
+            "templateUrl": [
+                "./city-attorney.component.html"
+            ],
+            "viewProviders": [],
+            "inputsClass": [],
+            "outputsClass": [],
+            "propertiesClass": [
+                {
+                    "name": "candidate",
+                    "type": "Candidate",
+                    "optional": false,
+                    "description": "",
+                    "line": 12
+                },
+                {
+                    "name": "candidateImages",
+                    "defaultValue": "[]",
+                    "type": "string[]",
+                    "optional": false,
+                    "description": "",
+                    "line": 15
+                },
+                {
+                    "name": "candidateImg",
+                    "type": "string",
+                    "optional": false,
+                    "description": "",
+                    "line": 13
+                },
+                {
+                    "name": "candidates",
+                    "type": "any[]",
+                    "optional": false,
+                    "description": "",
+                    "line": 11
+                },
+                {
+                    "name": "isExpanded",
+                    "defaultValue": "false",
+                    "type": "boolean",
+                    "optional": false,
+                    "description": "",
+                    "line": 16
+                }
+            ],
+            "methodsClass": [
+                {
+                    "name": "getCandidate",
+                    "args": [
+                        {
+                            "name": "candidate",
+                            "type": "Candidate"
+                        }
+                    ],
+                    "optional": false,
+                    "returnType": "void",
+                    "typeParameters": [],
+                    "line": 28,
+                    "jsdoctags": [
+                        {
+                            "name": "candidate",
+                            "type": "Candidate",
+                            "tagName": {
+                                "text": "param"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "name": "getCandidateImg",
+                    "args": [
+                        {
+                            "name": "img",
+                            "type": "string"
+                        }
+                    ],
+                    "optional": false,
+                    "returnType": "void",
+                    "typeParameters": [],
+                    "line": 33,
+                    "jsdoctags": [
+                        {
+                            "name": "img",
+                            "type": "string",
+                            "tagName": {
+                                "text": "param"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "name": "ngOnInit",
+                    "args": [],
+                    "optional": false,
+                    "returnType": "void",
+                    "typeParameters": [],
+                    "line": 20
+                },
+                {
+                    "name": "onClose",
+                    "args": [
+                        {
+                            "name": "event",
+                            "type": "boolean"
+                        }
+                    ],
+                    "optional": false,
+                    "returnType": "void",
+                    "typeParameters": [],
+                    "line": 37,
+                    "jsdoctags": [
+                        {
+                            "name": "event",
+                            "type": "boolean",
+                            "tagName": {
+                                "text": "param"
+                            }
+                        }
+                    ]
+                }
+            ],
+            "hostBindings": [],
+            "hostListeners": [],
+            "description": "",
+            "rawdescription": "",
+            "type": "component",
+            "sourceCode": "import { Component, OnInit } from '@angular/core';\r\nimport { Candidate } from '../../candidate';\r\nimport { CandidateService } from '../../services/candidate.service';\r\n\r\n@Component({\r\n  selector: 'app-city-attorney',\r\n  templateUrl: './city-attorney.component.html',\r\n  styleUrls: ['./city-attorney.component.scss']\r\n})\r\nexport class CityAttorneyComponent implements OnInit {\r\n  candidates: any[];\r\n  candidate: Candidate;\r\n  candidateImg: string;\r\n  \r\n  candidateImages: string[] = [];\r\n  isExpanded: boolean = false;\r\n\r\n  constructor(private candidateService: CandidateService) { }\r\n\r\n  ngOnInit() {\r\n    this.candidateService.getCityAttorneys().then(\r\n      attorneys => {\r\n        this.candidates = attorneys;\r\n      }\r\n    );\r\n  }\r\n\r\n  getCandidate(candidate: Candidate) {\r\n    this.candidate = candidate;\r\n    this.isExpanded = true;\r\n  }\r\n\r\n  getCandidateImg(img: string) {\r\n    this.candidateImg = img;\r\n  }\r\n\r\n  onClose(event: boolean) {\r\n    this.isExpanded = event;\r\n  }\r\n\r\n}\r\n",
+            "assetsDirs": [],
+            "styleUrlsData": [
+                {
+                    "data": ".candidate-cards {\r\n    padding: 10px 20px;\r\n}",
+                    "styleUrl": "./city-attorney.component.scss"
+                }
+            ],
+            "stylesData": "",
+            "constructorObj": {
+                "name": "constructor",
+                "description": "",
+                "args": [
+                    {
+                        "name": "candidateService",
+                        "type": "CandidateService"
+                    }
+                ],
+                "line": 16,
+                "jsdoctags": [
+                    {
+                        "name": "candidateService",
+                        "type": "CandidateService",
+                        "tagName": {
+                            "text": "param"
+                        }
+                    }
+                ]
+            },
+            "implements": [
+                "OnInit"
+            ],
+            "templateData": "<div class=\"candidate-cards p-grid p-justify-left p-nogutter\">\r\n\r\n  <!-- Expanded Candidate Card -->\r\n  <app-candidate-card-expanded class=\"p-col-12\" *ngIf=\"isExpanded\" [candidate]=\"candidate\" [candidateImg]=\"candidateImg\" (isExpanded)=\"onClose($event)\"></app-candidate-card-expanded>\r\n\r\n  <!-- Primary Candidate Card -->\r\n  <div *ngFor=\"let candidate of candidates; let i = index\">\r\n    <app-candidate-card *ngIf=\"candidate\" [candidate]=\"candidate\" [candidateImg]=\"candidateImages[i]\" (emitCandidateData)=\"getCandidate($event)\" (emitCandidateImage)=\"getCandidateImg($event)\"></app-candidate-card>\r\n  </div>\r\n\r\n</div>\r\n"
+        },
+        {
+            "name": "CityCouncilDistrictComponent",
+            "id": "component-CityCouncilDistrictComponent-f81043d1d693dbd5b32f2ffd7fb54723",
+            "file": "src/app/components/city-council-district/city-council-district.component.ts",
+            "encapsulation": [],
+            "entryComponents": [],
+            "inputs": [],
+            "outputs": [],
+            "providers": [],
+            "selector": "app-city-council-district",
+            "styleUrls": [
+                "./city-council-district.component.scss"
+            ],
+            "styles": [],
+            "templateUrl": [
+                "./city-council-district.component.html"
+            ],
+            "viewProviders": [],
+            "inputsClass": [],
+            "outputsClass": [],
+            "propertiesClass": [
+                {
+                    "name": "candidate",
+                    "type": "Candidate",
+                    "optional": false,
+                    "description": "",
+                    "line": 13
+                },
+                {
+                    "name": "candidateImages",
+                    "defaultValue": "[]",
+                    "type": "string[]",
+                    "optional": false,
+                    "description": "",
+                    "line": 16
+                },
+                {
+                    "name": "candidateImg",
+                    "type": "string",
+                    "optional": false,
+                    "description": "",
+                    "line": 14
+                },
+                {
+                    "name": "candidates",
+                    "type": "any[]",
+                    "optional": false,
+                    "description": "",
+                    "line": 12
+                },
+                {
+                    "name": "isExpanded",
+                    "defaultValue": "false",
+                    "type": "boolean",
+                    "optional": false,
+                    "description": "",
+                    "line": 17
+                }
+            ],
+            "methodsClass": [
+                {
+                    "name": "ngOnInit",
+                    "args": [],
+                    "optional": false,
+                    "returnType": "void",
+                    "typeParameters": [],
+                    "line": 21
+                },
+                {
+                    "name": "onClose",
+                    "args": [
+                        {
+                            "name": "event",
+                            "type": "boolean"
+                        }
+                    ],
+                    "optional": false,
+                    "returnType": "void",
+                    "typeParameters": [],
+                    "line": 46,
+                    "jsdoctags": [
+                        {
+                            "name": "event",
+                            "type": "boolean",
+                            "tagName": {
+                                "text": "param"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "name": "setCandidate",
+                    "args": [
+                        {
+                            "name": "candidate",
+                            "type": "Candidate"
+                        }
+                    ],
+                    "optional": false,
+                    "returnType": "void",
+                    "typeParameters": [],
+                    "line": 37,
+                    "jsdoctags": [
+                        {
+                            "name": "candidate",
+                            "type": "Candidate",
+                            "tagName": {
+                                "text": "param"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "name": "setCandidateImg",
+                    "args": [
+                        {
+                            "name": "img",
+                            "type": "string"
+                        }
+                    ],
+                    "optional": false,
+                    "returnType": "void",
+                    "typeParameters": [],
+                    "line": 42,
+                    "jsdoctags": [
+                        {
+                            "name": "img",
+                            "type": "string",
+                            "tagName": {
+                                "text": "param"
+                            }
+                        }
+                    ]
+                }
+            ],
+            "hostBindings": [],
+            "hostListeners": [],
+            "description": "",
+            "rawdescription": "",
+            "type": "component",
+            "sourceCode": "import { Component, OnInit } from '@angular/core';\r\nimport { ActivatedRoute } from '@angular/router'\r\nimport { Candidate } from '../../candidate';\r\nimport { CandidateService } from '../../services/candidate.service';\r\n\r\n@Component({\r\n  selector: 'app-city-council-district',\r\n  templateUrl: './city-council-district.component.html',\r\n  styleUrls: ['./city-council-district.component.scss']\r\n})\r\nexport class CityCouncilDistrictComponent implements OnInit {\r\n  candidates: any[];\r\n  candidate: Candidate;\r\n  candidateImg: string;\r\n  \r\n  candidateImages: string[] = [];\r\n  isExpanded: boolean = false;\r\n\r\n  constructor(private candidateService: CandidateService, private route: ActivatedRoute) { }\r\n\r\n  ngOnInit() {\r\n    this.route.paramMap.subscribe(params => {\r\n      \r\n      const district = params.get('id');\r\n\r\n      this.isExpanded = false;\r\n\r\n      this.candidateService.getCityCouncilorsByDistrict(district).then(\r\n        districtCouncilors => {\r\n          this.candidates = districtCouncilors;\r\n        }\r\n      );\r\n\r\n    });\r\n  }\r\n\r\n  setCandidate(candidate: Candidate) {\r\n    this.candidate = candidate;\r\n    this.isExpanded = true;\r\n  }\r\n\r\n  setCandidateImg(img: string) {\r\n    this.candidateImg = img;\r\n  }\r\n\r\n  onClose(event: boolean) {\r\n    this.isExpanded = event;\r\n  }\r\n\r\n}\r\n",
+            "assetsDirs": [],
+            "styleUrlsData": [
+                {
+                    "data": ".candidate-cards {\r\n  padding: 10px 20px;\r\n}\r\n",
+                    "styleUrl": "./city-council-district.component.scss"
+                }
+            ],
+            "stylesData": "",
+            "constructorObj": {
+                "name": "constructor",
+                "description": "",
+                "args": [
+                    {
+                        "name": "candidateService",
+                        "type": "CandidateService"
+                    },
+                    {
+                        "name": "route",
+                        "type": "ActivatedRoute"
+                    }
+                ],
+                "line": 17,
+                "jsdoctags": [
+                    {
+                        "name": "candidateService",
+                        "type": "CandidateService",
+                        "tagName": {
+                            "text": "param"
+                        }
+                    },
+                    {
+                        "name": "route",
+                        "type": "ActivatedRoute",
+                        "tagName": {
+                            "text": "param"
+                        }
+                    }
+                ]
+            },
+            "implements": [
+                "OnInit"
+            ],
+            "templateData": "<div class=\"candidate-cards p-grid p-justify-left p-nogutter\">\r\n\r\n  <!-- Expanded Candidate Card -->\r\n  <app-candidate-card-expanded class=\"p-col-12\" *ngIf=\"isExpanded\" [candidate]=\"candidate\" [candidateImg]=\"candidateImg\" (isExpanded)=\"onClose($event)\"></app-candidate-card-expanded>\r\n\r\n  <!-- Primary Candidate Card -->\r\n  <div *ngFor=\"let candidate of candidates; let i = index\">\r\n    <app-candidate-card *ngIf=\"candidate\" [candidate]=\"candidate\" [candidateImg]=\"candidateImages[i]\" (emitCandidateData)=\"setCandidate($event)\" (emitCandidateImage)=\"setCandidateImg($event)\"></app-candidate-card>\r\n  </div>\r\n\r\n</div>\r\n"
+        },
+        {
+            "name": "FaqComponent",
+            "id": "component-FaqComponent-316ea321612a6f0d064ac284c06a2de6",
+            "file": "src/app/components/faq/faq.component.ts",
+            "encapsulation": [],
+            "entryComponents": [],
+            "inputs": [],
+            "outputs": [],
+            "providers": [],
+            "selector": "app-faq",
+            "styleUrls": [
+                "./faq.component.scss"
+            ],
+            "styles": [],
+            "templateUrl": [
+                "./faq.component.html"
+            ],
+            "viewProviders": [],
+            "inputsClass": [],
+            "outputsClass": [],
+            "propertiesClass": [],
+            "methodsClass": [
+                {
+                    "name": "ngOnInit",
+                    "args": [],
+                    "optional": false,
+                    "returnType": "void",
+                    "typeParameters": [],
+                    "line": 12
+                }
+            ],
+            "hostBindings": [],
+            "hostListeners": [],
+            "description": "",
+            "rawdescription": "",
+            "type": "component",
+            "sourceCode": "import { Component, OnInit } from '@angular/core';\r\n\r\n@Component({\r\n  selector: 'app-faq',\r\n  templateUrl: './faq.component.html',\r\n  styleUrls: ['./faq.component.scss']\r\n})\r\nexport class FaqComponent implements OnInit {\r\n\r\n  constructor() { }\r\n\r\n  ngOnInit() {\r\n  }\r\n\r\n}\r\n",
+            "assetsDirs": [],
+            "styleUrlsData": [
+                {
+                    "data": "@import \"../../styles/variables\";\r\n@import \"../../styles/elements\";\r\n@import \"../../styles/global\";\r\n@import \"~@fortawesome/fontawesome-free/css/all.min.css\";\r\n\r\n\r\n.faq{\r\n        padding:20px 40px 40px 40px;\r\n        margin:20px 40px;\r\n        background-color:#ffffff;\r\n        box-shadow: $vvshadow;\r\n\r\n        h1{\r\n            margin:20px 0px 30px 0px;\r\n            text-align: left;\r\n        }\r\n\r\n        .fact{\r\n            color: $vvblue;\r\n            font-weight:normal;\r\n            margin-bottom:5px;\r\n            font-size: 18px;\r\n            line-height: 1.4;\r\n            max-width: 800px;\r\n        }\r\n\r\n        .answer{\r\n            margin-top:0px !important;\r\n            color: $vvdarkgrey;\r\n            margin-bottom: 20px;\r\n            font-size: 14px;\r\n            line-height: 1.4;\r\n            font-weight: 100;\r\n            max-width: 1200px;\r\n        }\r\n       \r\n  \r\n}\r\n",
+                    "styleUrl": "./faq.component.scss"
+                }
+            ],
+            "stylesData": "",
+            "constructorObj": {
+                "name": "constructor",
+                "description": "",
+                "args": [],
+                "line": 8
+            },
+            "implements": [
+                "OnInit"
+            ],
+            "templateData": "<div class=\"faq\">\r\n  <h1>Frequently Asked Questions</h1>\r\n  <h3 class=\"fact\">Where is this data sourced?</h3>\r\n\r\n\r\n  <p class=\"answer\">All of our data is sourced directly from the <a href=\"https://ssl.netfile.com/static/agency/csd/\"\r\n      target=\"_blank\">City of San Diego</a> public records. It is our priority to show you unbiased accurate\r\n    information about campaign finance.</p>\r\n\r\n\r\n  <h3 class=\"fact\">How often is this site updated?</h3>\r\n\r\n  <p class=\"answer\">Our data is pulled from the <a href=\"https://ssl.netfile.com/static/agency/csd/\"\r\n      target=\"_blank\">City of San Diego</a> public records multiple times a week to ensure you are able to see the\r\n    latest campaign finance data for your local elections.\r\n  </p>\r\n\r\n\r\n  <h3 class=\"fact\">Who manages this site?</h3>\r\n  <p class=\"answer\">This site is a collaboration between the Voters' Voice Initiatives, a non-partisan community group\r\n    advocating for election reform and Open San Diego, a brigade of the national, non-partisan Code for America.\r\n  </p>\r\n\r\n\r\n  <h3 class=\"fact\">How do I find out what city council district I am in?</h3>\r\n  <p class=\"answer\">You can use our built-in district finder or use the city’s finder.\r\n  </p>\r\n\r\n\r\n  <h3 class=\"fact\">What is outside money?</h3>\r\n  <p class=\"answer\">Outside money refers to all independent expenditures for or against a candidate.\r\n  </p>\r\n\r\n  <h3 class=\"fact\">What is an independent expenditure?</h3>\r\n  <p class=\"answer\">Independent expenditures are campaign contributions for communications that expressly advocate for the election or defeat of a candidate that is not made in cooperation, consultation or concert with; or at the request or suggestion of a candidate, candidate's authorized committee or political party.\r\n  </p>\r\n\r\n  <h3 class=\"fact\">What is the difference between donating to a candidate's campaign committee and donating to an independent expenditure committee supporting the candidate?</h3>\r\n  <p class=\"answer\">In the city of San Diego, candidates running for municipal office are subject to campaign finance limits on how much you can donate.  For City Council the limit is $1200 and for Mayor and City Attorney it is currently $2,300.\r\n    There are no limits to how much money you can donate to an independent expenditure committee working separately on behalf of, or against a candidate.\r\n  </p>\r\n\r\n\r\n  <h3 class=\"fact\">How does this effort help reduce the impact of money on politics?</h3>\r\n  <p class=\"answer\">Campaign finance disclosure is an essential public accountability mechanism.  Providing public access to this kind of information about the flow of money in elections empowers oversight and accountability in the government decision-making process.  Data transparency is critical to maintaining public trust.</p>\r\n\r\n  <h3 class=\"fact\">What are Democracy Dollars?</h3>\r\n  <p class=\"answer\">Democracy Dollars are a method of public financing of elections which can be an effective tool to increase voter engagement, expand opportunity for more community members of diverse experience to run for office and combat the rising influence of money on political outcomings.</p>\r\n\r\n  <h3 class=\"fact\">How do Democracy Dollars work?</h3>\r\n  <p class=\"answer\">Candidates receive public funds to finance their campaigns for office. In this program each registered voter would receive (4) democracy dollar certificates worth $25 each to give to the candidate(s) of their choice running for Mayor, City Attorney or City Council.<br/><br/>\r\n    Candidates qualify for public funds by raising a threshold number of small donor contributions and agree to forego big dollar contributions. Once qualified, candidates are able to fund their campaign by asking for and receiving Democracy Dollars from the voters.  This ensures that candidates are beholden to the public they represent and voters have a voice in who makes it to the ballot box.\r\n    You can read more about it <a href=\"https://sdvotersvoice.org/how-does-it-work%3F\" target=\"_blank\">here.</a></p>\r\n\r\n\r\n\r\n</div>"
+        },
+        {
+            "name": "HomeComponent",
+            "id": "component-HomeComponent-b42ea336c026880774a18db19dd0bd9c",
+            "file": "src/app/components/home/home.component.ts",
+            "encapsulation": [
+                "ViewEncapsulation.None"
+            ],
+            "entryComponents": [],
+            "inputs": [],
+            "outputs": [],
+            "providers": [],
+            "selector": "app-home",
+            "styleUrls": [
+                "./home.component.scss"
+            ],
+            "styles": [],
+            "templateUrl": [
+                "./home.component.html"
+            ],
+            "viewProviders": [],
+            "inputsClass": [],
+            "outputsClass": [],
+            "propertiesClass": [
+                {
+                    "name": "candidates",
+                    "type": "Record<string | CandidateTree>",
+                    "optional": false,
+                    "description": "",
+                    "line": 22
+                },
+                {
+                    "name": "councilDistrictStep",
+                    "defaultValue": "-1",
+                    "type": "number",
+                    "optional": false,
+                    "description": "",
+                    "line": 17
+                },
+                {
+                    "name": "isExpanded",
+                    "defaultValue": "false",
+                    "type": "boolean",
+                    "optional": false,
+                    "description": "",
+                    "line": 14
+                },
+                {
+                    "name": "lastUpdatedDate",
+                    "defaultValue": "'00/00/00'",
+                    "type": "string",
+                    "optional": false,
+                    "description": "",
+                    "line": 20
+                },
+                {
+                    "name": "modifiedData",
+                    "defaultValue": "{}",
+                    "type": "literal type",
+                    "optional": false,
+                    "description": "",
+                    "line": 23
+                },
+                {
+                    "name": "officeStep",
+                    "defaultValue": "-1",
+                    "type": "number",
+                    "optional": false,
+                    "description": "",
+                    "line": 16
+                },
+                {
+                    "name": "officeType",
+                    "type": "string",
+                    "optional": false,
+                    "description": "",
+                    "line": 19
+                },
+                {
+                    "name": "selectedCandidate",
+                    "type": "string",
+                    "optional": false,
+                    "description": "",
+                    "line": 18
+                },
+                {
+                    "name": "showSubmenu",
+                    "defaultValue": "false",
+                    "type": "boolean",
+                    "optional": false,
+                    "description": "",
+                    "line": 15
+                },
+                {
+                    "name": "sidenav",
+                    "type": "MatDrawer",
+                    "optional": false,
+                    "description": "",
+                    "line": 26,
+                    "decorators": [
+                        {
+                            "name": "ViewChild",
+                            "stringifiedArguments": "'drawer', {static: true}"
+                        }
+                    ]
+                },
+                {
+                    "name": "sortedObj",
+                    "defaultValue": "{}",
+                    "type": "literal type",
+                    "optional": false,
+                    "description": "",
+                    "line": 24
+                }
+            ],
+            "methodsClass": [
+                {
+                    "name": "asIsOrder",
+                    "args": [
+                        {
+                            "name": "a",
+                            "type": ""
+                        },
+                        {
+                            "name": "b",
+                            "type": ""
+                        }
+                    ],
+                    "optional": false,
+                    "returnType": "number",
+                    "typeParameters": [],
+                    "line": 141,
+                    "jsdoctags": [
+                        {
+                            "name": "a",
+                            "type": "",
+                            "tagName": {
+                                "text": "param"
+                            }
+                        },
+                        {
+                            "name": "b",
+                            "type": "",
+                            "tagName": {
+                                "text": "param"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "name": "massageCandidateData",
+                    "args": [],
+                    "optional": false,
+                    "returnType": "void",
+                    "typeParameters": [],
+                    "line": 100
+                },
+                {
+                    "name": "ngOnInit",
+                    "args": [],
+                    "optional": false,
+                    "returnType": "void",
+                    "typeParameters": [],
+                    "line": 52
+                },
+                {
+                    "name": "resetSidenav",
+                    "args": [],
+                    "optional": false,
+                    "returnType": "void",
+                    "typeParameters": [],
+                    "line": 87
+                },
+                {
+                    "name": "selectSidenavCandidate",
+                    "args": [
+                        {
+                            "name": "candidateKey",
+                            "type": "string"
+                        }
+                    ],
+                    "optional": false,
+                    "returnType": "void",
+                    "typeParameters": [],
+                    "line": 81,
+                    "jsdoctags": [
+                        {
+                            "name": "candidateKey",
+                            "type": "string",
+                            "tagName": {
+                                "text": "param"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "name": "setCouncilDistrictStep",
+                    "args": [
+                        {
+                            "name": "index",
+                            "type": ""
+                        }
+                    ],
+                    "optional": false,
+                    "returnType": "void",
+                    "typeParameters": [],
+                    "line": 76,
+                    "jsdoctags": [
+                        {
+                            "name": "index",
+                            "type": "",
+                            "tagName": {
+                                "text": "param"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "name": "setOfficeStep",
+                    "args": [
+                        {
+                            "name": "index",
+                            "type": ""
+                        }
+                    ],
+                    "optional": false,
+                    "returnType": "void",
+                    "typeParameters": [],
+                    "line": 66,
+                    "jsdoctags": [
+                        {
+                            "name": "index",
+                            "type": "",
+                            "tagName": {
+                                "text": "param"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "name": "setOfficeType",
+                    "args": [
+                        {
+                            "name": "type",
+                            "type": ""
+                        }
+                    ],
+                    "optional": false,
+                    "returnType": "void",
+                    "typeParameters": [],
+                    "line": 71,
+                    "jsdoctags": [
+                        {
+                            "name": "type",
+                            "type": "",
+                            "tagName": {
+                                "text": "param"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "name": "sortObj",
+                    "args": [
+                        {
+                            "name": "modifiedObject",
+                            "type": ""
+                        }
+                    ],
+                    "optional": false,
+                    "returnType": "{}",
+                    "typeParameters": [],
+                    "line": 126,
+                    "modifierKind": [
+                        112
+                    ],
+                    "jsdoctags": [
+                        {
+                            "name": "modifiedObject",
+                            "type": "",
+                            "tagName": {
+                                "text": "param"
+                            }
+                        }
+                    ]
+                }
+            ],
+            "hostBindings": [],
+            "hostListeners": [
+                {
+                    "name": "window:resize",
+                    "args": [
+                        {
+                            "name": "event",
+                            "type": ""
+                        }
+                    ],
+                    "argsDecorator": [
+                        "$event"
+                    ],
+                    "line": 42
+                }
+            ],
+            "description": "",
+            "rawdescription": "",
+            "type": "component",
+            "sourceCode": "import { Component, HostListener, OnInit, ViewEncapsulation, ViewChild } from '@angular/core';\r\nimport { MatDrawer } from '@angular/material/sidenav';\r\nimport { CandidateService, SidenavService } from '../../services';\r\nimport { CandidateTree } from '../../candidate';\r\n\r\n\r\n@Component({\r\n  selector: 'app-home',\r\n  templateUrl: './home.component.html',\r\n  styleUrls: ['./home.component.scss'],\r\n  encapsulation: ViewEncapsulation.None\r\n})\r\nexport class HomeComponent implements OnInit {\r\n  isExpanded: boolean = false;\r\n  showSubmenu: boolean = false;\r\n  officeStep: number = -1;\r\n  councilDistrictStep: number = -1;\r\n  selectedCandidate: string;\r\n  officeType: string;\r\n  lastUpdatedDate: string = '00/00/00';\r\n\r\n  candidates: Record<string, CandidateTree>;\r\n  modifiedData: {} = {};\r\n  sortedObj: {} = {};\r\n\r\n  @ViewChild('drawer', { static: true }) sidenav: MatDrawer;\r\n\r\n  constructor(\r\n    private candidateService: CandidateService,\r\n    private sidenavService: SidenavService,\r\n  ) {\r\n    sidenavService.candidateNameEmittedFromCard$.subscribe(res => {\r\n      this.selectedCandidate = res;\r\n    });\r\n\r\n    sidenavService.candidateTypeEmittedFromSplash$.subscribe(res => {\r\n      this.officeType = res;\r\n    });\r\n  }\r\n\r\n  @HostListener('window:resize', ['$event'])\r\n  onResize(event): void {\r\n    if (this.sidenav !== undefined) {\r\n      if (event.target.innerWidth <= 1000) {\r\n        this.sidenav.close();\r\n      } else {\r\n        this.sidenav.open();\r\n      }\r\n    }\r\n  }\r\n\r\n  ngOnInit() {\r\n    this.candidateService.getAll().then(\r\n      (all: Record<string, CandidateTree>) => {\r\n        this.candidates = all;\r\n\r\n        this.massageCandidateData();\r\n      }\r\n    )\r\n\r\n    this.candidateService.getLastUpdated()\r\n      .subscribe(date => this.lastUpdatedDate = date);\r\n  }\r\n\r\n  // Have active-link class apply to only an opened candidate office panel by setting an assigned step for each candidate office section\r\n  setOfficeStep(index,) {\r\n    this.officeStep = index;\r\n  }\r\n\r\n  // Assign officeType variable with the value of the candidateType.key when opening office panel to check expanded condition on the mat-expansion-panel\r\n  setOfficeType(type) {\r\n    this.officeType = type;\r\n  }\r\n\r\n  // Have only one city council district side panel open at any time by setting an assigned step for each panel distrct\r\n  setCouncilDistrictStep(index) {\r\n    this.councilDistrictStep = index;\r\n  }\r\n\r\n  // Apply highlight style to candidate name when selected, open candidate card when candidate name is clicked\r\n  selectSidenavCandidate(candidateKey: string) {\r\n    this.selectedCandidate = candidateKey;\r\n    this.sidenavService.emitCandidateKeySidenav(candidateKey);\r\n  }\r\n\r\n  // Reset sidenav when navigating away from any of the candidate offices, close panels and remove style highlight\r\n  resetSidenav() {\r\n    this.officeStep = null;\r\n    this.officeType = null;\r\n    this.selectedCandidate = null;\r\n  }\r\n\r\n  // data is turned into a key value pair\r\n  //object like this\r\n  //{\r\n  //  mayor:{},\r\n  //  city-council:{},\r\n  //  city-attorney:{}\r\n  //}\r\n  massageCandidateData() {\r\n\r\n    this.modifiedData[\"city council\"] = {} as CandidateTree;\r\n    this.modifiedData[\"city council\"][\"title\"] = \"City Council\";\r\n    this.modifiedData[\"city council\"][\"name\"] = \"City Council\";\r\n    this.modifiedData[\"city council\"][\"deepTree\"] = true;\r\n    this.modifiedData[\"city council\"][\"candidates\"] = {};\r\n\r\n    const entries = Object.entries(this.candidates);\r\n\r\n    entries.forEach(entry => {\r\n      if (!entry[\"0\"].toLowerCase().includes(\"last\")) {\r\n        if (!entry[\"0\"].toLowerCase().includes(\"city-council\")) {\r\n          this.modifiedData[entry[\"0\"]] = entry[\"1\"];\r\n          this.modifiedData[entry[\"0\"]][\"deeptree\"]= false;\r\n        } else {\r\n          this.modifiedData[\"city council\"][\"candidates\"][entry[\"0\"].slice(-1)] = entry[\"1\"];\r\n        }\r\n      }\r\n\r\n    });\r\n\r\n    this.sortedObj = this.sortObj(this.modifiedData);\r\n  }\r\n\r\n\r\n  private sortObj(modifiedObject) {\r\n    let temp = {};\r\n    let modData = this.modifiedData;\r\n    var sortedEntries = Object.keys(modifiedObject).sort(function (a, b) {\r\n      return b.charCodeAt(0) - a.charCodeAt(0);\r\n    });\r\n\r\n    sortedEntries.forEach(x => {\r\n      temp[x] = modData[x];\r\n    });\r\n\r\n    return temp;\r\n\r\n  }\r\n\r\n  asIsOrder(a, b) {\r\n    return 1;\r\n  }\r\n}\r\n",
+            "assetsDirs": [],
+            "styleUrlsData": [
+                {
+                    "data": "@import \"../../styles/variables\";\r\n@import \"../../styles/elements\";\r\n@import \"../../styles/global\";\r\n@import \"~@fortawesome/fontawesome-free/css/all.min.css\";\r\n.router-link-active {\r\n  color: $vvyellow !important;\r\n}\r\n\r\n.main_section{\r\n  background-color: $vvbackground;\r\n}\r\n.full-width{\r\n  padding: 0px;\r\n}\r\n.logo{\r\n  &:focus{\r\n    outline: none !important;\r\n  }\r\n}\r\n.sidenav-container {\r\n  height: 100vh;\r\n  border: 1px solid rgba(0, 0, 0, 0.5);\r\n\r\n  .mat-accordion {\r\n\r\n    .mat-expansion-panel {\r\n      border-radius: 0px !important;\r\n      box-shadow: none !important;\r\n      border-bottom: 1px solid #F5F5F5;\r\n\r\n      .mat-expansion-panel-content {\r\n        background: lighten($vvbackground, 3%);\r\n        .mat-expansion-panel-body {\r\n          padding: 0 20px 0;\r\n          margin: 0 10px;\r\n        \r\n        }\r\n      \r\n        i {\r\n          opacity: 0.7;\r\n        }\r\n\r\n        .mat-expansion-panel-header {\r\n          .mat-content{\r\n            display: flex;\r\n            justify-content: space-between;\r\n            //margin: 0;\r\n          }\r\n\r\n          .mat-expansion-indicator {\r\n            padding: 0 5px;\r\n          }\r\n          transition: none;\r\n          background: lighten($vvbackground, 3%);\r\n          padding: 5px 0px;\r\n\r\n          &:hover {\r\n            background: lighten($vvbackground, 3%) !important;\r\n            border-bottom: 2px $vvlightblue solid;\r\n            font-style: italic;\r\n          }\r\n\r\n        }\r\n      }\r\n    }\r\n\r\n    .active-link {\r\n      background-color: $vvlightblue !important;\r\n      \r\n\r\n      .mat-content .mat-expansion-panel-header-title {\r\n        color: $vvlightgrey;         \r\n      }\r\n    }\r\n\r\n    .mat-expansion-panel-header {\r\n      transition: 300ms ease;\r\n      .mat-content .mat-expansion-panel-header-title {\r\n        text-transform: uppercase;\r\n        font-weight: bold;\r\n      }\r\n\r\n      &:hover {\r\n        background-color: lighten($vvlightblue, 10%) !important;\r\n\r\n        .mat-content .mat-expansion-panel-header-title {\r\n          color: $vvlightgrey;         \r\n        }\r\n      }\r\n      \r\n    }\r\n\r\n    .mat-expansion-panel-body {\r\n      ul {\r\n        list-style-type: none;\r\n        padding: 0px;\r\n\r\n        li {\r\n          margin: 0 0 5px 0;\r\n\r\n          &:hover {\r\n            font-weight: bold;\r\n            color: $vvlightblue;\r\n            cursor: pointer;\r\n          }\r\n        }\r\n      }\r\n    }\r\n\r\n    .candidate-selected {\r\n      font-weight: bold;\r\n      color: $vvlightblue;\r\n    }\r\n\r\n    .district-selected {\r\n      background: lighten($vvbackground, 3%) !important;\r\n      border-bottom: 2px $vvlightblue solid;\r\n      font-style: italic;\r\n    }\r\n}\r\n\r\n  .submenu {\r\n    overflow-y: hidden;\r\n    transition: transform 300ms ease;\r\n    transform: scaleY(0);\r\n    transform-origin: top;\r\n    padding-left: 30px;\r\n    background: $vvlightgrey;\r\n  }\r\n\r\n  .submenu.expanded {\r\n    transform: scaleY(1);\r\n  }\r\n\r\n  .menu-button-expand {\r\n    transition: 300ms ease-in-out;\r\n    transform: rotate(0deg);\r\n  }\r\n\r\n  .menu-button-expand.rotated {\r\n    transform: rotate(180deg);\r\n  }\r\n\r\n  mat-nav-list {\r\n    width: 15vw;\r\n    padding-top: 0;\r\n  }\r\n}\r\n\r\n:host ::ng-deep .mat-list-item-content {\r\n  font-size: 20px;\r\n  font-weight: 500;\r\n}\r\n\r\n@media (max-width: 1200px) {\r\n\r\n  .header-nav{\r\n    .bar-toggle{\r\n      display:block !important;\r\n      color:#fff;\r\n      padding-right:20px;\r\n      font-size:22px;\r\n    }\r\n    grid-template-columns: auto 3fr auto auto !important;\r\n  }\r\n  .sidenav-container {\r\n    mat-drawer {\r\n      width: 150px;\r\n    }\r\n    .mat-accordion {\r\n      .mat-expansion-panel {\r\n        width: 150px;\r\n        .mat-expansion-panel-content {\r\n          .mat-expansion-panel-header {\r\n            font-size: 12px;\r\n            padding: 5px 16px 0px 16px;\r\n          }\r\n\r\n          .mat-expansion-panel-body {\r\n            padding: 0px;\r\n          }\r\n\r\n          .fa-map-marked-alt {\r\n            padding-top: 4px;\r\n          }\r\n        }\r\n\r\n        .mat-expansion-panel-header {\r\n          font-size: 12px;\r\n          padding: 0 12px;\r\n        }\r\n\r\n        .mat-expansion-panel-body {\r\n          padding: 0px;\r\n      \r\n          ul li {\r\n            font-size: 12px;\r\n            padding: 0 16px;\r\n          }\r\n        }\r\n      }\r\n    }\r\n  }\r\n}\r\n\r\n.header-nav{\r\n  .bar-toggle{\r\n    display:none;\r\n    color:#fff;\r\n  }\r\n  font-size: 18px;\r\n  display: grid;\r\n  grid-template-columns: 3fr auto auto;\r\n  padding: 10px 20px;\r\n  text-align: left;\r\n  background-color: $vvdarkblue;\r\n  align-items: center;\r\n  .nav_links {\r\n      margin-left: 20px;\r\n      margin-right: 20px;\r\n      color: #ffffff;\r\n      text-decoration: none;\r\n      font-weight: 100;\r\n      &:hover {\r\n          text-decoration: underline;\r\n          color: $vvyellow;\r\n        }\r\n        &:active {\r\n          color: $vvyellow;\r\n        }\r\n    }\r\n}\r\n\r\n\r\n\r\n/*Footer*/\r\n.footer {\r\n  display: grid;\r\n  grid-template-columns: 3fr auto;\r\n  padding: 40px 40px 40px 40px;\r\n  color: $vvdarkblue;\r\n  border:none;\r\n  background-color: $vvbackground;\r\n\r\n  h3 {\r\n    font-size: 14px;\r\n    font-weight: 700;\r\n    line-height: 1.2;\r\n    margin-bottom: 5px;\r\n    margin-right: 40px;\r\n  }\r\n\r\n  p {\r\n    font-size: 14px;\r\n    font-weight: 400;\r\n    line-height: 1.3;\r\n    max-width: 600px;\r\n    margin-right: 40px;\r\n    margin-bottom: 20px;\r\n  }\r\n}\r\n\r\n.footer_links {\r\n  margin: 20px 20px 20px 0px;\r\n  display: inline-block;\r\n  \r\n\r\n  font-weight: 400;\r\n  font-size: 14px;\r\n  line-height: 1.5;\r\n  text-decoration: none;\r\n  color: $vvblue;\r\n\r\n\r\n\r\n.footer_logo {\r\n  align-self: center;\r\n  justify-self: center;\r\n  margin-right: 20px;\r\n}\r\n.updated{\r\n color: $vvgreen;\r\n font-style: italic;\r\n font-size: 12px;\r\n}\r\n\r\n/*Hover States*/\r\n\r\n.subheadline p a:hover,\r\n.nav_links:hover,\r\n.footer_links:hover {\r\n  text-decoration: underline;\r\n}\r\n\r\n\r\n\r\n\r\n\r\n}\r\n\r\n/*CTA Stack*/\r\n@media only screen and (max-width: 636px) {\r\n  .headline {\r\n    font-size: 26px;\r\n  }\r\n  .races {\r\n    grid-template-columns: 1fr;\r\n    grid-row-gap: 20px;\r\n    grid-column-gap: 0px;\r\n    max-width: 300px !important;\r\n  }\r\n\r\n  .subheadline {\r\n    margin: auto;\r\n  }\r\n\r\n  .footer {\r\n    grid-template-columns: 1fr;\r\n    text-align: center;\r\n   \r\n    h3 {\r\n      font-size: 14px;\r\n      margin-right: 0px;\r\n    }\r\n\r\n    p {\r\n      margin-right: 0px;\r\n    }\r\n  }\r\n\r\n\r\n\r\n  .last {\r\n    margin-right: 0px !important;\r\n  }\r\n}\r\n",
+                    "styleUrl": "./home.component.scss"
+                }
+            ],
+            "stylesData": "",
+            "constructorObj": {
+                "name": "constructor",
+                "description": "",
+                "args": [
+                    {
+                        "name": "candidateService",
+                        "type": "CandidateService"
+                    },
+                    {
+                        "name": "sidenavService",
+                        "type": "SidenavService"
+                    }
+                ],
+                "line": 26,
+                "jsdoctags": [
+                    {
+                        "name": "candidateService",
+                        "type": "CandidateService",
+                        "tagName": {
+                            "text": "param"
+                        }
+                    },
+                    {
+                        "name": "sidenavService",
+                        "type": "SidenavService",
+                        "tagName": {
+                            "text": "param"
+                        }
+                    }
+                ]
+            },
+            "implements": [
+                "OnInit"
+            ],
+            "templateData": "<div class=\"header-nav\">\r\n  <i class=\"fa fa-bars bar-toggle\" (click)=\"drawer.toggle()\"></i>\r\n  <div>\r\n    <img class=\"logo\" src=\"../../../assets/home/VV_Logo_Reversed@2x.png\" alt=\"Voter's Voice Initiative\" width=\"120\" height=\"auto\"\r\n      routerLinkActive=\"active-link\" routerLink=\"/splash\" (click)=\"resetSidenav()\">\r\n  </div>\r\n  <a class=\"nav_links\" routerLink=\"/about\" routerLinkActive=\"router-link-active\" (click)=\"resetSidenav()\">About</a>\r\n  <a class=\"nav_links\" routerLink=\"/faq\" routerLinkActive=\"router-link-active\" (click)=\"resetSidenav()\">FAQ</a>\r\n</div>\r\n\r\n<mat-drawer-container class=\"sidenav-container\">\r\n  <mat-drawer #drawer mode=\"side\" align=\"start\" disableClose=\"false\" opened>\r\n    <mat-nav-list [disableRipple]=\"true\">\r\n      <mat-accordion displayMode=\"flat\">\r\n\r\n        <ng-container *ngFor=\"let candidateType of sortedObj | keyvalue: asIsOrder; let i= index\">\r\n\r\n          <mat-expansion-panel [expanded]=\"officeType === candidateType.key\" (opened)=\"setOfficeStep(i); setOfficeType(candidateType.key)\" hideToggle=\"true\" (closed)=\"setCouncilDistrictStep(-1)\">\r\n\r\n            <mat-expansion-panel-header [ngClass]=\"{'active-link':officeStep===i}\" collapsedHeight=\"50px\" expandedHeight=\"50px\" \r\n               [routerLink]=\"candidateType.value.deepTree? []: '/'+ candidateType.key\">\r\n              <mat-panel-title>\r\n                {{candidateType.value.title}}\r\n              </mat-panel-title>\r\n            </mat-expansion-panel-header>\r\n\r\n            <ng-container *ngIf=\"!candidateType.value.deepTree; else elseBlockContainer\">\r\n              <ul *ngFor=\"let member of candidateType.value.candidates | keyvalue; let j=index\">\r\n                <li>\r\n                  <a [ngClass]=\"{ 'candidate-selected': selectedCandidate === member.key }\" (click)=\"selectSidenavCandidate(member.key)\">{{member.key}}</a>\r\n                </li>\r\n              </ul>\r\n            </ng-container>\r\n\r\n            <!-- city council subcategory and its sub properties -->\r\n            <ng-template #elseBlockContainer>\r\n              <mat-expansion-panel *ngFor=\"let candidate of candidateType.value.candidates | keyvalue; let j=index\" [expanded]=\"councilDistrictStep===j\"\r\n                (opened)=\"setCouncilDistrictStep(j)\" class=\"mat-elevation-z0\" [routerLink]=\"['city-council/district', candidate.key]\">\r\n                <mat-expansion-panel-header [ngClass]=\"{ 'district-selected': councilDistrictStep === j }\" collapsedHeight=\"30px\" expandedHeight=\"30px\">\r\n                  {{candidate.value.name}}\r\n                </mat-expansion-panel-header>\r\n                <ul *ngFor=\"let member of candidate.value.candidates | keyvalue; let x= index\">\r\n                  <li>\r\n                    <a [ngClass]=\"{ 'candidate-selected': selectedCandidate === member.key }\" (click)=\"selectSidenavCandidate(member.key)\">{{member.key}}</a>\r\n                  </li>\r\n                </ul>\r\n              </mat-expansion-panel>\r\n            </ng-template>\r\n            <!-- city council -->\r\n\r\n          </mat-expansion-panel>\r\n        </ng-container>\r\n      </mat-accordion>\r\n    </mat-nav-list>\r\n  </mat-drawer>\r\n\r\n  <mat-drawer-content class=\"main_section\">\r\n    <router-outlet></router-outlet>\r\n    <div class=\"footer\">\r\n      <div>\r\n        <div class=\"footer_nav\">\r\n          <div class=\"footer_links\">\r\n            <a routerLink=\"/about\">About</a>\r\n          </div>\r\n          <div class=\"footer_links\">\r\n            <a routerLink=\"/faq\">FAQ</a>\r\n          </div>\r\n          <div class=\"footer_links last\">\r\n            <a href=\"https://registertovote.ca.gov/\" target=\"_blank\" rel=\"noopener noreferrer\">Register to Vote</a>\r\n          </div>\r\n        </div>\r\n        <div>\r\n          <h3>Brought to you by the Voters' Voice Initiatives and San Diego’s Public Ethics Commission</h3>\r\n          <p>The San Diego Campaign Finance Dashboard is being developed by volunteers in a non-partisan coalition as a service\r\n            to our community. Data has been gathered from public records posted by the\r\n            <a href=\"https://ssl.netfile.com/static/agency/csd/\"\r\n              target=\"_blank\">City of San Diego Clerk’s Office\r\n            </a> in order to create the graphs and summaries for each candidate’s campaign.</p>\r\n        </div>\r\n      </div>\r\n      <div class=\"footer_logo\">\r\n        <img src=\"../../../assets/home/VV_Logo_Color@2x.png\" alt=\"Voter's Voice Initiative\" width=\"120\" height=\"auto\">\r\n        <p class=\"updated\">Last Updated {{ lastUpdatedDate }}</p>\r\n      </div>\r\n    </div>\r\n  </mat-drawer-content>\r\n</mat-drawer-container>\r\n"
+        },
+        {
+            "name": "MayorComponent",
+            "id": "component-MayorComponent-a69e13d17a6f7d7fa71400fd7c938af5",
+            "file": "src/app/components/mayor/mayor.component.ts",
+            "encapsulation": [],
+            "entryComponents": [],
+            "inputs": [],
+            "outputs": [],
+            "providers": [],
+            "selector": "app-mayor",
+            "styleUrls": [
+                "./mayor.component.scss"
+            ],
+            "styles": [],
+            "templateUrl": [
+                "./mayor.component.html"
+            ],
+            "viewProviders": [],
+            "inputsClass": [],
+            "outputsClass": [],
+            "propertiesClass": [
+                {
+                    "name": "candidate",
+                    "type": "Candidate",
+                    "optional": false,
+                    "description": "",
+                    "line": 12
+                },
+                {
+                    "name": "candidateImages",
+                    "defaultValue": "[\r\n    'assets/candidates/2020/mayor/barbara_bry/barbara_bry.png',\r\n    // 'assets/candidates/2020/mayor/tasha_williamson/tasha_williamson.png',\r\n    'assets/candidates/2020/mayor/todd_gloria/todd_gloria.png',\r\n  ]",
+                    "type": "string[]",
+                    "optional": false,
+                    "description": "",
+                    "line": 15
+                },
+                {
+                    "name": "candidateImg",
+                    "type": "string",
+                    "optional": false,
+                    "description": "",
+                    "line": 13
+                },
+                {
+                    "name": "candidates",
+                    "type": "any[]",
+                    "optional": false,
+                    "description": "",
+                    "line": 11
+                },
+                {
+                    "name": "isExpanded",
+                    "defaultValue": "false",
+                    "type": "boolean",
+                    "optional": false,
+                    "description": "",
+                    "line": 21
+                }
+            ],
+            "methodsClass": [
+                {
+                    "name": "getCandidate",
+                    "args": [
+                        {
+                            "name": "candidate",
+                            "type": "Candidate"
+                        }
+                    ],
+                    "optional": false,
+                    "returnType": "void",
+                    "typeParameters": [],
+                    "line": 33,
+                    "jsdoctags": [
+                        {
+                            "name": "candidate",
+                            "type": "Candidate",
+                            "tagName": {
+                                "text": "param"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "name": "getCandidateImg",
+                    "args": [
+                        {
+                            "name": "img",
+                            "type": "string"
+                        }
+                    ],
+                    "optional": false,
+                    "returnType": "void",
+                    "typeParameters": [],
+                    "line": 38,
+                    "jsdoctags": [
+                        {
+                            "name": "img",
+                            "type": "string",
+                            "tagName": {
+                                "text": "param"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "name": "ngOnInit",
+                    "args": [],
+                    "optional": false,
+                    "returnType": "void",
+                    "typeParameters": [],
+                    "line": 25
+                },
+                {
+                    "name": "onClose",
+                    "args": [
+                        {
+                            "name": "event",
+                            "type": "boolean"
+                        }
+                    ],
+                    "optional": false,
+                    "returnType": "void",
+                    "typeParameters": [],
+                    "line": 42,
+                    "jsdoctags": [
+                        {
+                            "name": "event",
+                            "type": "boolean",
+                            "tagName": {
+                                "text": "param"
+                            }
+                        }
+                    ]
+                }
+            ],
+            "hostBindings": [],
+            "hostListeners": [],
+            "description": "",
+            "rawdescription": "",
+            "type": "component",
+            "sourceCode": "import { Component, OnInit } from '@angular/core';\r\nimport { Candidate } from '../../candidate';\r\nimport { CandidateService } from '../../services/candidate.service';\r\n\r\n@Component({\r\n  selector: 'app-mayor',\r\n  templateUrl: './mayor.component.html',\r\n  styleUrls: ['./mayor.component.scss']\r\n})\r\nexport class MayorComponent implements OnInit {\r\n  candidates: any[];\r\n  candidate: Candidate;\r\n  candidateImg: string;\r\n  \r\n  candidateImages: string[] = [\r\n    'assets/candidates/2020/mayor/barbara_bry/barbara_bry.png',\r\n    // 'assets/candidates/2020/mayor/tasha_williamson/tasha_williamson.png',\r\n    'assets/candidates/2020/mayor/todd_gloria/todd_gloria.png',\r\n  ];\r\n  \r\n  isExpanded: boolean = false;\r\n\r\n  constructor(private candidateService: CandidateService) { }\r\n\r\n  ngOnInit() {\r\n    this.candidateService.getMayors().then(\r\n      mayors => {\r\n        this.candidates = mayors;\r\n      }\r\n    );\r\n  }\r\n\r\n  getCandidate(candidate: Candidate) {\r\n    this.candidate = candidate;\r\n    this.isExpanded = true;\r\n  }\r\n\r\n  getCandidateImg(img: string) {\r\n    this.candidateImg = img;\r\n  }\r\n\r\n  onClose(event: boolean) {\r\n    this.isExpanded = event;\r\n  }\r\n\r\n}\r\n",
+            "assetsDirs": [],
+            "styleUrlsData": [
+                {
+                    "data": ".candidate-cards{\r\n    padding:10px 20px;\r\n}\r\n",
+                    "styleUrl": "./mayor.component.scss"
+                }
+            ],
+            "stylesData": "",
+            "constructorObj": {
+                "name": "constructor",
+                "description": "",
+                "args": [
+                    {
+                        "name": "candidateService",
+                        "type": "CandidateService"
+                    }
+                ],
+                "line": 21,
+                "jsdoctags": [
+                    {
+                        "name": "candidateService",
+                        "type": "CandidateService",
+                        "tagName": {
+                            "text": "param"
+                        }
+                    }
+                ]
+            },
+            "implements": [
+                "OnInit"
+            ],
+            "templateData": "<div class=\"candidate-cards p-grid p-justify-left p-nogutter\">\r\n\r\n  <!-- Expanded Candidate Card -->\r\n  <app-candidate-card-expanded class=\"p-col-12\" *ngIf=\"isExpanded\" [candidate]=\"candidate\" [candidateImg]=\"candidateImg\" (isExpanded)=\"onClose($event)\"></app-candidate-card-expanded>\r\n\r\n  <!-- Primary Candidate Card -->\r\n  <div *ngFor=\"let candidate of candidates; let i = index\">\r\n    <app-candidate-card *ngIf=\"candidate\" [candidate]=\"candidate\" [candidateImg]=\"candidateImages[i]\" (emitCandidateData)=\"getCandidate($event)\" (emitCandidateImage)=\"getCandidateImg($event)\"></app-candidate-card>\r\n  </div>\r\n\r\n</div>\r\n"
+        },
+        {
+            "name": "SplashComponent",
+            "id": "component-SplashComponent-ef14843ad9988f25fbc3a8177783b1cf",
+            "file": "src/app/components/splash/splash.component.ts",
+            "encapsulation": [],
+            "entryComponents": [],
+            "inputs": [],
+            "outputs": [],
+            "providers": [],
+            "selector": "app-splash",
+            "styleUrls": [
+                "./splash.component.scss"
+            ],
+            "styles": [],
+            "templateUrl": [
+                "./splash.component.html"
+            ],
+            "viewProviders": [],
+            "inputsClass": [],
+            "outputsClass": [],
+            "propertiesClass": [
+                {
+                    "name": "campaignTotals",
+                    "defaultValue": "{\r\n    mayor: '0',\r\n    cityAttorney: '0',\r\n    cityCouncil: '0'\r\n  }",
+                    "type": "object",
+                    "optional": false,
+                    "description": "",
+                    "line": 17
+                },
+                {
+                    "name": "candidateCounts",
+                    "defaultValue": "{\r\n    mayor: '0',\r\n    cityAttorney: '0',\r\n    cityCouncil: '0'\r\n  }",
+                    "type": "object",
+                    "optional": false,
+                    "description": "",
+                    "line": 23
+                }
+            ],
+            "methodsClass": [
+                {
+                    "name": "ngOnInit",
+                    "args": [],
+                    "optional": false,
+                    "returnType": "void",
+                    "typeParameters": [],
+                    "line": 29
+                },
+                {
+                    "name": "selectOffice",
+                    "args": [
+                        {
+                            "name": "officeType",
+                            "type": "string"
+                        }
+                    ],
+                    "optional": false,
+                    "returnType": "void",
+                    "typeParameters": [],
+                    "line": 39,
+                    "jsdoctags": [
+                        {
+                            "name": "officeType",
+                            "type": "string",
+                            "tagName": {
+                                "text": "param"
+                            }
+                        }
+                    ]
+                }
+            ],
+            "hostBindings": [],
+            "hostListeners": [],
+            "description": "",
+            "rawdescription": "",
+            "type": "component",
+            "sourceCode": "import { Component, OnInit } from '@angular/core';\r\nimport { SidenavService } from '../../services';\r\nimport { CandidateService } from '../../services/candidate.service';\r\n\r\n@Component({\r\n  selector: 'app-splash',\r\n  templateUrl: './splash.component.html',\r\n  styleUrls: ['./splash.component.scss']\r\n})\r\nexport class SplashComponent implements OnInit {\r\n\r\n  constructor(\r\n    private sidenavService: SidenavService,\r\n    private candidateService: CandidateService\r\n  ) { }\r\n\r\n  campaignTotals = {\r\n    mayor: '0',\r\n    cityAttorney: '0',\r\n    cityCouncil: '0'\r\n  }\r\n\r\n  candidateCounts = {\r\n    mayor: '0',\r\n    cityAttorney: '0',\r\n    cityCouncil: '0'\r\n  }\r\n\r\n  ngOnInit() {\r\n\r\n    this.candidateService.getCampaignTotals()\r\n      .subscribe(totals => this.campaignTotals = totals);\r\n\r\n    this.candidateService.getNumberOfCandidates()\r\n      .subscribe(counts => this.candidateCounts = counts);\r\n\r\n  }\r\n\r\n  selectOffice(officeType: string) {\r\n    this.sidenavService.emitCandidateTypeSplash(officeType);\r\n  }\r\n\r\n}\r\n",
+            "assetsDirs": [],
+            "styleUrlsData": [
+                {
+                    "data": "@import \"../../styles/variables\";\r\n@import \"../../styles/elements\";\r\n@import \"../../styles/global\";\r\n@import \"~@fortawesome/fontawesome-free/css/all.min.css\";\r\n\r\n.splashpage{\r\n  padding:20px 40px 0px 30px;\r\n}\r\n.whorwe{\r\n \r\n  background-image: url(\"../../../assets/splash/bg-whorwe@2x.jpg\");\r\n  background-size: 100% 100%;\r\n    background-position: 50% 50%;\r\n  color:#fff;\r\n  margin: auto;\r\n  text-align:center;\r\n  padding:40px;\r\n  font-weight: 100;\r\n  box-shadow: $vvshadow;\r\n\r\n  .goals{\r\n    display: grid;\r\n    grid-template-columns: 1fr 1fr 1fr 1fr;\r\n    align-content: center;\r\n    column-gap: 20px;\r\n    margin: 0px auto 40px auto;\r\n    \r\n\r\n    .bullet{\r\n      font-weight:bold;\r\n      font-size:14px;\r\n      max-width:170px;\r\n      margin: auto;\r\n    }\r\n\r\n    .bullet-icon{\r\n      display: block;\r\n      margin:20px auto;\r\n      font-size: 30px;\r\n     \r\n    }\r\n  }\r\n\r\n\r\n  h1{\r\n    font-size:18px;\r\n    font-weight:bold;\r\n    padding:0;\r\n    margin-top:0px;\r\n    margin-bottom:20px;\r\n    color:#fff;\r\n\r\n  }\r\n  .vv-description{\r\n    margin-top:0px;\r\n    margin-bottom:20px;\r\n    font-size:14px;\r\n    line-height: 1.4;\r\n    max-width: 600px;\r\n    margin-left:auto;\r\n    margin-right:auto;\r\n \r\n  }\r\n  a {\r\n    color: $vvyellow;\r\n    text-decoration: none;\r\n    \r\n   \r\n    &:hover {\r\n        text-decoration: underline;\r\n      }\r\n  }\r\n}\r\n\r\n.ftm{\r\n  margin: 20px auto 20px auto;\r\n  text-align:center;\r\n  padding:40px 40px 60px 40px;\r\n  font-weight: 100;\r\n  box-shadow: $vvshadow;\r\n  color:#4E4E4E;\r\n  background-color: #fff;\r\n  h1{\r\n    margin: 0px;\r\n  }\r\n  p{\r\n    margin:10px 0px 20px 0px;\r\n    line-height: 1.4;\r\n  }\r\n  .ftm_caption{\r\n   \r\n    display: block;\r\n    margin:10px auto 20px auto;\r\n  }\r\n  .choose{\r\n    display: grid;\r\n    grid-template-columns: 1fr 1fr 1fr;\r\n    align-content: center;\r\n    \r\n\r\n    div{\r\n      border-right:2px solid $vvbackground;\r\n    }\r\n    div:last-child{\r\n      border-right:none;\r\n    }\r\n\r\n\r\n      .cta{\r\n\r\n          @include button-styles;\r\n          padding: 10px 20px;\r\n          max-width: 200px;\r\n          text-decoration: none;\r\n          a{\r\n            text-decoration: none;\r\n          }\r\n          i{\r\n            padding:0px;\r\n            margin:0px 8px 0px 0px;\r\n            font-size:14px;\r\n          }\r\n      }\r\n      .cta:hover{\r\n            background-color: $vvlightblue;\r\n        }\r\n}\r\n\r\n    .racename{\r\n        font-size: 20px;\r\n        margin-bottom: 30px;\r\n     \r\n  }\r\n  .raised{\r\n    margin:40px 0px  5px 0px;\r\n  }\r\n  .candidate_num{\r\n    margin:10px 0px  5px 0px;\r\n  }\r\n  h3{\r\n    font-size:20px;\r\n    margin: 0px;\r\n  }\r\n  .amount_raised{\r\n    color:#289A58;\r\n  }\r\n  \r\n}\r\n\r\n.sources{\r\n  margin-top:60px;\r\n  font-size:14px;\r\n  a{\r\n    color:$vvlightblue;\r\n  }\r\n  p{\r\n    margin:0px !important;\r\n  }\r\n}\r\n\r\n@media only screen and (max-width: 1000px) {\r\n\r\n  .goals{\r\n    grid-template-columns: 1fr 1fr!important;\r\n    row-gap: 20px;\r\n    max-width:500px;\r\n   \r\n  }\r\n  .choose{\r\n    grid-template-columns: 1fr !important;\r\n    row-gap: 20px;\r\n    div{\r\n      border-bottom:2px solid $vvbackground !important;\r\n      border-right:none!important;\r\n      padding-bottom: 40px;\r\n    }\r\n    div:last-child{\r\n      border-bottom:none!important;\r\n      padding-bottom: 0px;\r\n    }\r\n  }\r\n  \r\n}\r\n\r\n@media only screen and (max-width: 400px) {\r\n\r\n\r\n  .goals{\r\n    grid-template-columns: 1fr!important;\r\n    row-gap: 20px;\r\n    max-width:500px;\r\n   \r\n  }\r\n\r\n\r\n}",
+                    "styleUrl": "./splash.component.scss"
+                }
+            ],
+            "stylesData": "",
+            "constructorObj": {
+                "name": "constructor",
+                "description": "",
+                "args": [
+                    {
+                        "name": "sidenavService",
+                        "type": "SidenavService"
+                    },
+                    {
+                        "name": "candidateService",
+                        "type": "CandidateService"
+                    }
+                ],
+                "line": 10,
+                "jsdoctags": [
+                    {
+                        "name": "sidenavService",
+                        "type": "SidenavService",
+                        "tagName": {
+                            "text": "param"
+                        }
+                    },
+                    {
+                        "name": "candidateService",
+                        "type": "CandidateService",
+                        "tagName": {
+                            "text": "param"
+                        }
+                    }
+                ]
+            },
+            "implements": [
+                "OnInit"
+            ],
+            "templateData": "<div class=\"splashpage\">\r\n  <div class=\"whorwe\" [style.backgroundSize]=\"'cover'\">\r\n      <h1>Who's Behind the Voters' Voice Initiatives?</h1>\r\n      <p class=\"vv-description\">The Voters’ Voice Initiatives is a non-partisan coalition (including <a href=\"https://represent.us/\">Represent.us</a> and the \r\n        <a href=\"https://www.lwv.org/\">League of Women Voters</a>) working to give “We The People” a greater voice in our local government by:</p>\r\n        <div class=\"goals\">\r\n            <div>\r\n                <i class=\"fa fa-binoculars bullet-icon\"></i>\r\n                <p class=\"bullet\">Improving Transparency in Campaign Finance</p>\r\n            </div>\r\n            <div>\r\n                <i class=\"fa fa-money bullet-icon\"></i>\r\n                <p class=\"bullet\">Providing Full Disclosure on the Flow of Money</p>\r\n            </div>\r\n            <div>\r\n                <i class=\"fa fa-handshake-o bullet-icon\"></i>\r\n                <p class=\"bullet\">Reducing the Potential for Corruption</p>\r\n            </div>\r\n            <div>\r\n                <i class=\"fa fa-gavel bullet-icon\"></i>\r\n                <p class=\"bullet\">Increasing Accountability in Government</p>\r\n            </div>\r\n        </div>\r\n      <a routerLink=\"/about\">Learn About Us</a>\r\n  </div>\r\n  <div class=\"ftm\">\r\n    <h1>Follow the Money</h1>\r\n    <p class=\"ftm_caption\">See how local campaigns are financed so you can be informed before you vote.</p>\r\n    <div class=\"choose\">\r\n        <div>\r\n            <h2 class=\"racename\">Mayor</h2> \r\n            <a class=\"cta\" routerLinkActive=\"active-link\" routerLink=\"/mayor\" (click)=\"selectOffice('mayor')\"><i class=\"fa fa-university\"></i>See Candidates</a>\r\n            <p class=\"raised\">Total Raised</p>\r\n            <h3 class=\"amount_raised\">${{ campaignTotals.mayor | roundCurrencyDisplay: 1 }}</h3>\r\n            <p class=\"candidate_num\">Candidates</p>\r\n            <h3>{{ candidateCounts.mayor }}</h3>\r\n        </div>\r\n        <div>\r\n            <h2 class=\"racename\">City Attorney</h2> \r\n            <a class=\"cta\" routerLinkActive=\"active-link\" routerLink=\"/city-attorney\" (click)=\"selectOffice('city-attorney')\"><i class=\"fa fa-balance-scale\"></i>See Candidates</a>\r\n            <p class=\"raised\">Total Raised</p>\r\n            <h3 class=\"amount_raised\">${{ campaignTotals.cityAttorney | roundCurrencyDisplay: 1 }}</h3>\r\n            <p class=\"candidate_num\">Candidates</p>\r\n            <h3>{{ candidateCounts.cityAttorney }}</h3>\r\n        </div>\r\n        <div>\r\n            <h2 class=\"racename\">City Council</h2> \r\n            <a class=\"cta\" routerLinkActive=\"active-link\" routerLink=\"/city-council\" (click)=\"selectOffice('city council')\"><i class=\"fas fa-map-marked-alt\"></i>Choose District</a>\r\n            <p class=\"raised\">Total Raised</p>\r\n            <h3 class=\"amount_raised\">${{ campaignTotals.cityCouncil | roundCurrencyDisplay: 1 }}</h3>\r\n            <p class=\"candidate_num\">Candidates</p>\r\n            <h3>{{ candidateCounts.cityCouncil }}</h3>\r\n        </div>\r\n    </div>\r\n    <div class=\"sources\"><p>All of our data is sourced directly from the <a href=\"https://ssl.netfile.com/static/agency/csd/\" target=\"_blank\">City of San Diego</a> public records.</p></div>\r\n\r\n</div>\r\n \r\n</div>"
+        },
+        {
+            "name": "UnderConstructionComponent",
+            "id": "component-UnderConstructionComponent-02b371072099a03dfe4290202ef7a63b",
+            "file": "src/app/components/under-construction/under-construction.component.ts",
+            "encapsulation": [],
+            "entryComponents": [],
+            "inputs": [],
+            "outputs": [],
+            "providers": [],
+            "selector": "app-under-construction",
+            "styleUrls": [
+                "./under-construction.component.scss"
+            ],
+            "styles": [],
+            "templateUrl": [
+                "./under-construction.component.html"
+            ],
+            "viewProviders": [],
+            "inputsClass": [],
+            "outputsClass": [],
+            "propertiesClass": [],
+            "methodsClass": [
+                {
+                    "name": "ngOnInit",
+                    "args": [],
+                    "optional": false,
+                    "returnType": "void",
+                    "typeParameters": [],
+                    "line": 13
+                }
+            ],
+            "hostBindings": [],
+            "hostListeners": [],
+            "description": "",
+            "rawdescription": "",
+            "type": "component",
+            "sourceCode": "import { Component, OnInit } from '@angular/core';\r\n\r\n@Component({\r\n  selector: 'app-under-construction',\r\n  templateUrl: './under-construction.component.html',\r\n  styleUrls: ['./under-construction.component.scss']\r\n  \r\n})\r\nexport class UnderConstructionComponent implements OnInit {\r\n\r\n  constructor() { }\r\n\r\n  ngOnInit() {\r\n  }\r\n\r\n}\r\n",
+            "assetsDirs": [],
+            "styleUrlsData": [
+                {
+                    "data": "@import \"../../styles/variables\";\r\n@import \"../../styles/elements\";\r\n@import \"../../styles/global\";\r\n@import \"~@fortawesome/fontawesome-free/css/all.min.css\";\r\n\r\n\r\n.construction{\r\n   \r\n    width:100%;\r\n    height: 100%;\r\n    margin:auto;\r\n    background-color: $vvbackground;\r\n  \r\n\r\n    .construction-box{\r\n        margin:auto;\r\n        max-width: 300px;\r\n    }\r\n\r\n}\r\n.crane{\r\n    margin:20vh auto 10px auto;\r\n    width:200px;\r\n    height:auto;\r\n    display: block;\r\n}\r\n\r\n",
+                    "styleUrl": "./under-construction.component.scss"
+                }
+            ],
+            "stylesData": "",
+            "constructorObj": {
+                "name": "constructor",
+                "description": "",
+                "args": [],
+                "line": 9
+            },
+            "implements": [
+                "OnInit"
+            ],
+            "templateData": "<div class=\"construction\">\r\n \r\n  <img class=\"crane\" src=\"../../../assets/under-construction/under-construction.png\"  width=\"67%\" height=\"auto\" alt=\"crane\"/>\r\n  <div class=\"construction-box\">\r\n   \r\n    <p class=\"h-sub\">This page is</p>\r\n    <h1>\r\n      Under Construction\r\n    </h1>\r\n  </div>\r\n</div>"
+        }
+    ],
+    "modules": [
+        {
+            "name": "AppModule",
+            "children": [
+                {
+                    "type": "providers",
+                    "elements": []
+                },
+                {
+                    "type": "declarations",
+                    "elements": [
+                        {
+                            "name": "AboutComponent"
+                        },
+                        {
+                            "name": "AppComponent"
+                        },
+                        {
+                            "name": "CandidateCardComponent"
+                        },
+                        {
+                            "name": "CandidateCardExpandedComponent"
+                        },
+                        {
+                            "name": "CityAttorneyComponent"
+                        },
+                        {
+                            "name": "CityCouncilDistrictComponent"
+                        },
+                        {
+                            "name": "FaqComponent"
+                        },
+                        {
+                            "name": "HomeComponent"
+                        },
+                        {
+                            "name": "MayorComponent"
+                        },
+                        {
+                            "name": "RoundCurrencyDisplayPipe"
+                        },
+                        {
+                            "name": "SplashComponent"
+                        },
+                        {
+                            "name": "UnderConstructionComponent"
+                        }
+                    ]
+                },
+                {
+                    "type": "imports",
+                    "elements": [
+                        {
+                            "name": "AppRoutingModule"
+                        }
+                    ]
+                },
+                {
+                    "type": "exports",
+                    "elements": []
+                },
+                {
+                    "type": "bootstrap",
+                    "elements": [
+                        {
+                            "name": "AppComponent"
+                        }
+                    ]
+                },
+                {
+                    "type": "classes",
+                    "elements": []
+                }
+            ]
+        },
+        {
+            "name": "AppRoutingModule",
+            "children": [
+                {
+                    "type": "providers",
+                    "elements": []
+                },
+                {
+                    "type": "declarations",
+                    "elements": []
+                },
+                {
+                    "type": "imports",
+                    "elements": []
+                },
+                {
+                    "type": "exports",
+                    "elements": []
+                },
+                {
+                    "type": "bootstrap",
+                    "elements": []
+                },
+                {
+                    "type": "classes",
+                    "elements": []
+                }
+            ]
+        }
+    ],
+    "miscellaneous": {
+        "variables": [
+            {
+                "name": "context",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "src/test.ts",
+                "type": "",
+                "defaultValue": "require.context('./', true, /\\.spec\\.ts$/)"
+            },
+            {
+                "name": "environment",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "src/environments/environment.prod.ts",
+                "type": "object",
+                "defaultValue": "{\r\n  production: true\r\n}"
+            },
+            {
+                "name": "environment",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "src/environments/environment.ts",
+                "type": "object",
+                "defaultValue": "{\r\n  production: false\r\n}"
+            },
+            {
+                "name": "placeholder_data",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "src/app/components/candidate-card-expanded/candidate-card-expanded.component.ts",
+                "type": "[]",
+                "defaultValue": "[\r\n  { colorCode: '#007431', industry: 'Technology', amount: 200000, percentage: 0.5 },\r\n  { colorCode: '#00903d', industry: 'Finance', amount: 200000, percentage: 0.2 },\r\n  { colorCode: '#00af4a', industry: 'Energy', amount: 200000, percentage: null },\r\n  { colorCode: '#00d359', industry: 'Construction', amount: 200000, percentage: null },\r\n  { colorCode: '#00fc6a', industry: 'Other', amount: 200000, percentage: null },\r\n]"
+            },
+            {
+                "name": "require",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "src/test.ts",
+                "type": "any"
+            }
+        ],
+        "functions": [],
+        "typealiases": [],
+        "enumerations": [],
+        "groupedVariables": {
+            "src/test.ts": [
+                {
+                    "name": "context",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "src/test.ts",
+                    "type": "",
+                    "defaultValue": "require.context('./', true, /\\.spec\\.ts$/)"
+                },
+                {
+                    "name": "require",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "src/test.ts",
+                    "type": "any"
+                }
+            ],
+            "src/environments/environment.prod.ts": [
+                {
+                    "name": "environment",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "src/environments/environment.prod.ts",
+                    "type": "object",
+                    "defaultValue": "{\r\n  production: true\r\n}"
+                }
+            ],
+            "src/environments/environment.ts": [
+                {
+                    "name": "environment",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "src/environments/environment.ts",
+                    "type": "object",
+                    "defaultValue": "{\r\n  production: false\r\n}"
+                }
+            ],
+            "src/app/components/candidate-card-expanded/candidate-card-expanded.component.ts": [
+                {
+                    "name": "placeholder_data",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "src/app/components/candidate-card-expanded/candidate-card-expanded.component.ts",
+                    "type": "[]",
+                    "defaultValue": "[\r\n  { colorCode: '#007431', industry: 'Technology', amount: 200000, percentage: 0.5 },\r\n  { colorCode: '#00903d', industry: 'Finance', amount: 200000, percentage: 0.2 },\r\n  { colorCode: '#00af4a', industry: 'Energy', amount: 200000, percentage: null },\r\n  { colorCode: '#00d359', industry: 'Construction', amount: 200000, percentage: null },\r\n  { colorCode: '#00fc6a', industry: 'Other', amount: 200000, percentage: null },\r\n]"
+                }
+            ]
+        },
+        "groupedFunctions": {},
+        "groupedEnumerations": {},
+        "groupedTypeAliases": {}
+    },
+    "routes": {
+        "name": "<root>",
+        "kind": "module",
+        "className": "AppModule",
+        "children": [
+            {
+                "name": "routes",
+                "filename": "src/app/app-routing.module.ts",
+                "module": "AppRoutingModule",
+                "children": [
+                    {
+                        "path": "",
+                        "redirectTo": "splash",
+                        "pathMatch": "full"
+                    },
+                    {
+                        "path": "splash",
+                        "component": "SplashComponent"
+                    },
+                    {
+                        "path": "faq",
+                        "component": "FaqComponent"
+                    },
+                    {
+                        "path": "about",
+                        "component": "AboutComponent"
+                    },
+                    {
+                        "path": "mayor",
+                        "component": "MayorComponent"
+                    },
+                    {
+                        "path": "city-attorney",
+                        "component": "CityAttorneyComponent"
+                    },
+                    {
+                        "path": "under-construction",
+                        "component": "UnderConstructionComponent"
+                    },
+                    {
+                        "path": "city-council/district/:id",
+                        "component": "CityCouncilDistrictComponent"
+                    }
+                ],
+                "kind": "module"
+            }
+        ]
+    },
+    "coverage": {
+        "count": 0,
+        "status": "low",
+        "files": [
+            {
+                "filePath": "e2e/src/app.po.ts",
+                "type": "class",
+                "linktype": "classe",
+                "name": "AppPage",
+                "coveragePercent": 0,
+                "coverageCount": "0/3",
+                "status": "low"
+            },
+            {
+                "filePath": "src/app/app.component.ts",
+                "type": "component",
+                "linktype": "component",
+                "name": "AppComponent",
+                "coveragePercent": 0,
+                "coverageCount": "0/2",
+                "status": "low"
+            },
+            {
+                "filePath": "src/app/candidate.alt.ts",
+                "type": "interface",
+                "linktype": "interface",
+                "name": "Candidate",
+                "coveragePercent": 0,
+                "coverageCount": "0/5",
+                "status": "low"
+            },
+            {
+                "filePath": "src/app/candidate.alt.ts",
+                "type": "interface",
+                "linktype": "interface",
+                "name": "Candidate2",
+                "coveragePercent": 0,
+                "coverageCount": "0/13",
+                "status": "low"
+            },
+            {
+                "filePath": "src/app/candidate.alt.ts",
+                "type": "interface",
+                "linktype": "interface",
+                "name": "CandidateTree",
+                "coveragePercent": 0,
+                "coverageCount": "0/4",
+                "status": "low"
+            },
+            {
+                "filePath": "src/app/candidate.ts",
+                "type": "interface",
+                "linktype": "interface",
+                "name": "Candidate",
+                "coveragePercent": 0,
+                "coverageCount": "0/5",
+                "status": "low"
+            },
+            {
+                "filePath": "src/app/candidate.ts",
+                "type": "interface",
+                "linktype": "interface",
+                "name": "CandidateTree",
+                "coveragePercent": 0,
+                "coverageCount": "0/4",
+                "status": "low"
+            },
+            {
+                "filePath": "src/app/components/about/about.component.ts",
+                "type": "component",
+                "linktype": "component",
+                "name": "AboutComponent",
+                "coveragePercent": 0,
+                "coverageCount": "0/3",
+                "status": "low"
+            },
+            {
+                "filePath": "src/app/components/candidate-card-expanded/candidate-card-expanded.component.ts",
+                "type": "component",
+                "linktype": "component",
+                "name": "CandidateCardExpandedComponent",
+                "coveragePercent": 0,
+                "coverageCount": "0/27",
+                "status": "low"
+            },
+            {
+                "filePath": "src/app/components/candidate-card-expanded/candidate-card-expanded.component.ts",
+                "type": "variable",
+                "linktype": "miscellaneous",
+                "linksubtype": "variable",
+                "name": "placeholder_data",
+                "coveragePercent": 0,
+                "coverageCount": "0/1",
+                "status": "low"
+            },
+            {
+                "filePath": "src/app/components/candidate-card/candidate-card.component.ts",
+                "type": "component",
+                "linktype": "component",
+                "name": "CandidateCardComponent",
+                "coveragePercent": 0,
+                "coverageCount": "0/8",
+                "status": "low"
+            },
+            {
+                "filePath": "src/app/components/city-attorney/city-attorney.component.ts",
+                "type": "component",
+                "linktype": "component",
+                "name": "CityAttorneyComponent",
+                "coveragePercent": 0,
+                "coverageCount": "0/11",
+                "status": "low"
+            },
+            {
+                "filePath": "src/app/components/city-council-district/city-council-district.component.ts",
+                "type": "component",
+                "linktype": "component",
+                "name": "CityCouncilDistrictComponent",
+                "coveragePercent": 0,
+                "coverageCount": "0/11",
+                "status": "low"
+            },
+            {
+                "filePath": "src/app/components/faq/faq.component.ts",
+                "type": "component",
+                "linktype": "component",
+                "name": "FaqComponent",
+                "coveragePercent": 0,
+                "coverageCount": "0/3",
+                "status": "low"
+            },
+            {
+                "filePath": "src/app/components/home/home.component.ts",
+                "type": "component",
+                "linktype": "component",
+                "name": "HomeComponent",
+                "coveragePercent": 0,
+                "coverageCount": "0/23",
+                "status": "low"
+            },
+            {
+                "filePath": "src/app/components/mayor/mayor.component.ts",
+                "type": "component",
+                "linktype": "component",
+                "name": "MayorComponent",
+                "coveragePercent": 0,
+                "coverageCount": "0/11",
+                "status": "low"
+            },
+            {
+                "filePath": "src/app/components/splash/splash.component.ts",
+                "type": "component",
+                "linktype": "component",
+                "name": "SplashComponent",
+                "coveragePercent": 0,
+                "coverageCount": "0/6",
+                "status": "low"
+            },
+            {
+                "filePath": "src/app/components/under-construction/under-construction.component.ts",
+                "type": "component",
+                "linktype": "component",
+                "name": "UnderConstructionComponent",
+                "coveragePercent": 0,
+                "coverageCount": "0/3",
+                "status": "low"
+            },
+            {
+                "filePath": "src/app/pipes/round-currency-display.pipe.ts",
+                "type": "pipe",
+                "linktype": "pipe",
+                "name": "RoundCurrencyDisplayPipe",
+                "coveragePercent": 0,
+                "coverageCount": "0/1",
+                "status": "low"
+            },
+            {
+                "filePath": "src/app/services/candidate.service.ts",
+                "type": "injectable",
+                "linktype": "injectable",
+                "name": "CandidateService",
+                "coveragePercent": 0,
+                "coverageCount": "0/12",
+                "status": "low"
+            },
+            {
+                "filePath": "src/app/services/sidenav.service.ts",
+                "type": "injectable",
+                "linktype": "injectable",
+                "name": "SidenavService",
+                "coveragePercent": 0,
+                "coverageCount": "0/11",
+                "status": "low"
+            },
+            {
+                "filePath": "src/environments/environment.prod.ts",
+                "type": "variable",
+                "linktype": "miscellaneous",
+                "linksubtype": "variable",
+                "name": "environment",
+                "coveragePercent": 0,
+                "coverageCount": "0/1",
+                "status": "low"
+            },
+            {
+                "filePath": "src/environments/environment.ts",
+                "type": "variable",
+                "linktype": "miscellaneous",
+                "linksubtype": "variable",
+                "name": "environment",
+                "coveragePercent": 0,
+                "coverageCount": "0/1",
+                "status": "low"
+            },
+            {
+                "filePath": "src/test.ts",
+                "type": "variable",
+                "linktype": "miscellaneous",
+                "linksubtype": "variable",
+                "name": "context",
+                "coveragePercent": 0,
+                "coverageCount": "0/1",
+                "status": "low"
+            },
+            {
+                "filePath": "src/test.ts",
+                "type": "variable",
+                "linktype": "miscellaneous",
+                "linksubtype": "variable",
+                "name": "require",
+                "coveragePercent": 0,
+                "coverageCount": "0/1",
+                "status": "low"
+            }
+        ]
+    }
+}

--- a/documentation.json
+++ b/documentation.json
@@ -46,6 +46,66 @@
             ],
             "ngname": "roundCurrencyDisplay",
             "sourceCode": "import { Pipe, PipeTransform } from \"@angular/core\";\r\n\r\n@Pipe({\r\n  name: \"roundCurrencyDisplay\",\r\n})\r\nexport class RoundCurrencyDisplayPipe implements PipeTransform {\r\n  transform(input: any, args?: any): any {\r\n    var exp,\r\n      oneMillion = 1000000,\r\n      suffixes = [\"k\", \"M\", \"G\", \"T\", \"P\", \"E\"];\r\n\r\n    if (Number.isNaN(input)) {\r\n      return null;\r\n    }\r\n \r\n    if (input < oneMillion) {\r\n      return Number(input).toLocaleString('en-US');\r\n    }\r\n\r\n    exp = Math.floor(Math.log(input) / Math.log(1000));\r\n\r\n    return (input / Math.pow(1000, exp)).toFixed(args) + suffixes[exp - 1];\r\n  }\r\n}\r\n"
+        },
+        {
+            "name": "RoundCurrencyPipe",
+            "id": "pipe-RoundCurrencyPipe-63d563b36244d3db1f408a054cb8fb84",
+            "file": "src/app/vv-charts/round-currency.pipe.ts",
+            "type": "pipe",
+            "description": "",
+            "properties": [],
+            "methods": [
+                {
+                    "name": "transform",
+                    "args": [
+                        {
+                            "name": "input",
+                            "type": "any"
+                        },
+                        {
+                            "name": "args",
+                            "type": "any",
+                            "optional": true
+                        },
+                        {
+                            "name": "threshold",
+                            "type": "any",
+                            "optional": true
+                        }
+                    ],
+                    "optional": false,
+                    "returnType": "any",
+                    "typeParameters": [],
+                    "line": 7,
+                    "jsdoctags": [
+                        {
+                            "name": "input",
+                            "type": "any",
+                            "tagName": {
+                                "text": "param"
+                            }
+                        },
+                        {
+                            "name": "args",
+                            "type": "any",
+                            "optional": true,
+                            "tagName": {
+                                "text": "param"
+                            }
+                        },
+                        {
+                            "name": "threshold",
+                            "type": "any",
+                            "optional": true,
+                            "tagName": {
+                                "text": "param"
+                            }
+                        }
+                    ]
+                }
+            ],
+            "ngname": "roundCurrency",
+            "sourceCode": "import { Pipe, PipeTransform } from \"@angular/core\";\r\n\r\n@Pipe({\r\n  name: \"roundCurrency\",\r\n})\r\nexport class RoundCurrencyPipe implements PipeTransform {\r\n  transform(input: any, args?: any, threshold?: any): any {\r\n    var exp,\r\n      oneMillion = 1000000,\r\n      minimum = Number.isNaN(threshold) ? oneMillion : Number(threshold),\r\n      suffixes = [\"k\", \"M\", \"G\", \"T\", \"P\", \"E\"];\r\n\r\n    if (Number.isNaN(input)) {\r\n      return null;\r\n    }\r\n \r\n    // if (input < oneMillion) {\r\n    if (input < minimum || input < 1000) {\r\n      return Number(input).toLocaleString('en-US');\r\n    }\r\n\r\n    exp = Math.floor(Math.log(input) / Math.log(1000));\r\n\r\n    return (input / Math.pow(1000, exp)).toFixed(args) + suffixes[exp - 1];\r\n  }\r\n}\r\n"
         }
     ],
     "interfaces": [
@@ -2125,6 +2185,193 @@
             "templateData": "<div class=\"candidate-cards p-grid p-justify-left p-nogutter\">\r\n\r\n  <!-- Expanded Candidate Card -->\r\n  <app-candidate-card-expanded class=\"p-col-12\" *ngIf=\"isExpanded\" [candidate]=\"candidate\" [candidateImg]=\"candidateImg\" (isExpanded)=\"onClose($event)\"></app-candidate-card-expanded>\r\n\r\n  <!-- Primary Candidate Card -->\r\n  <div *ngFor=\"let candidate of candidates; let i = index\">\r\n    <app-candidate-card *ngIf=\"candidate\" [candidate]=\"candidate\" [candidateImg]=\"candidateImages[i]\" (emitCandidateData)=\"getCandidate($event)\" (emitCandidateImage)=\"getCandidateImg($event)\"></app-candidate-card>\r\n  </div>\r\n\r\n</div>\r\n"
         },
         {
+            "name": "RaisedInOutDonutComponent",
+            "id": "component-RaisedInOutDonutComponent-b3ad2617d08571f495646c44588d01ce",
+            "file": "src/app/vv-charts/raised-in-out-donut/raised-in-out-donut.component.ts",
+            "encapsulation": [],
+            "entryComponents": [],
+            "inputs": [],
+            "outputs": [],
+            "providers": [],
+            "selector": "raised-in-out-donut",
+            "styleUrls": [
+                "./raised-in-out-donut.component.scss"
+            ],
+            "styles": [],
+            "templateUrl": [
+                "./raised-in-out-donut.component.html"
+            ],
+            "viewProviders": [],
+            "inputsClass": [
+                {
+                    "name": "areaName",
+                    "line": 17,
+                    "type": "string"
+                },
+                {
+                    "name": "inside",
+                    "line": 15,
+                    "type": "number"
+                },
+                {
+                    "name": "jurisdiction",
+                    "line": 18,
+                    "type": "string"
+                },
+                {
+                    "name": "jurisdictionSuffix",
+                    "line": 19,
+                    "type": "string"
+                },
+                {
+                    "name": "outside",
+                    "line": 16,
+                    "type": "number"
+                }
+            ],
+            "outputsClass": [],
+            "propertiesClass": [
+                {
+                    "name": "chartPlugins",
+                    "defaultValue": "[ pluginDataLabels ]",
+                    "type": "[]",
+                    "optional": false,
+                    "description": "",
+                    "line": 76
+                },
+                {
+                    "name": "doughnutChartColors",
+                    "defaultValue": "[\r\n    { backgroundColor: ['#3392ff', '#bfd63b'] },\r\n  ]",
+                    "type": "Color[]",
+                    "optional": false,
+                    "description": "",
+                    "line": 35
+                },
+                {
+                    "name": "doughnutChartData",
+                    "defaultValue": "[{\r\n    data: [1,1],\r\n  }]",
+                    "type": "ChartDataSets[]",
+                    "optional": false,
+                    "description": "",
+                    "line": 28
+                },
+                {
+                    "name": "doughnutChartLabels",
+                    "type": "Label[]",
+                    "optional": false,
+                    "description": "",
+                    "line": 32
+                },
+                {
+                    "name": "doughnutChartOptions",
+                    "defaultValue": "{\r\n    // responsive: true,\r\n    responsive: false,\r\n    maintainAspectRatio: false,\r\n    cutoutPercentage: 60,\r\n    animation: {\r\n      animateRotate: true,\r\n    },\r\n\r\n    legend: {\r\n      display: false,\r\n    },\r\n\r\n    tooltips: {\r\n      enabled: false,\r\n    },\r\n\r\n    plugins: {\r\n      datalabels: {\r\n        anchor: 'start',\r\n        align: 'start',\r\n        color: '#4e4e4e',\r\n        textAlign:'center',\r\n        display: 'auto',\r\n\r\n        font: {\r\n          size: 16,\r\n          weight: 'bold',\r\n        },\r\n\r\n        formatter: (value, context) => {\r\n          return this.doughnutChartLabels[context.dataIndex];\r\n        },\r\n      },\r\n    },\r\n  }",
+                    "type": "ChartOptions",
+                    "optional": false,
+                    "description": "",
+                    "line": 39
+                },
+                {
+                    "name": "doughnutChartType",
+                    "defaultValue": "'doughnut'",
+                    "type": "ChartType",
+                    "optional": false,
+                    "description": "",
+                    "line": 27
+                },
+                {
+                    "name": "jurisdictionComplete",
+                    "type": "string",
+                    "optional": false,
+                    "description": "",
+                    "line": 24
+                },
+                {
+                    "name": "title",
+                    "type": "string",
+                    "optional": false,
+                    "description": "",
+                    "line": 22
+                },
+                {
+                    "name": "tooltipText",
+                    "type": "string",
+                    "optional": false,
+                    "description": "",
+                    "line": 23
+                }
+            ],
+            "methodsClass": [
+                {
+                    "name": "mNumberFormatter",
+                    "args": [
+                        {
+                            "name": "num",
+                            "type": "number"
+                        }
+                    ],
+                    "optional": false,
+                    "returnType": "any",
+                    "typeParameters": [],
+                    "line": 98,
+                    "jsdoctags": [
+                        {
+                            "name": "num",
+                            "type": "number",
+                            "tagName": {
+                                "text": "param"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "name": "ngOnChanges",
+                    "args": [],
+                    "optional": false,
+                    "returnType": "void",
+                    "typeParameters": [],
+                    "line": 81
+                }
+            ],
+            "hostBindings": [],
+            "hostListeners": [],
+            "description": "",
+            "rawdescription": "",
+            "type": "component",
+            "sourceCode": "import { Component, OnChanges, Input } from '@angular/core';\r\n\r\nimport * as pluginDataLabels from 'chartjs-plugin-datalabels';\r\nimport { ChartOptions, ChartType, ChartDataSets } from 'chart.js';\r\nimport { Color, Label } from 'ng2-charts';\r\n\r\nimport { RoundCurrencyPipe } from '../round-currency.pipe'\r\n\r\n@Component({\r\n  selector: 'raised-in-out-donut',\r\n  templateUrl: './raised-in-out-donut.component.html',\r\n  styleUrls: ['./raised-in-out-donut.component.scss'],\r\n})\r\nexport class RaisedInOutDonutComponent implements OnChanges {\r\n  @Input() inside: number;\r\n  @Input() outside: number;\r\n  @Input() areaName: string; // Example: City of San Diego\r\n  @Input() jurisdiction: string; // Example: City, District\r\n  @Input() jurisdictionSuffix?: string; // Example '1', '5'\r\n\r\n\r\n  title: string;\r\n  tooltipText: string;\r\n  jurisdictionComplete: string;\r\n\r\n\r\n  doughnutChartType: ChartType = 'doughnut';\r\n  doughnutChartData: ChartDataSets[] = [{\r\n    data: [1,1],\r\n  }];\r\n  \r\n  doughnutChartLabels: Label[];\r\n\r\n\r\n  doughnutChartColors: Color[] = [\r\n    { backgroundColor: ['#3392ff', '#bfd63b'] },\r\n  ];\r\n\r\n  doughnutChartOptions: ChartOptions = {\r\n    // responsive: true,\r\n    responsive: false,\r\n    maintainAspectRatio: false,\r\n    cutoutPercentage: 60,\r\n    animation: {\r\n      animateRotate: true,\r\n    },\r\n\r\n    legend: {\r\n      display: false,\r\n    },\r\n\r\n    tooltips: {\r\n      enabled: false,\r\n    },\r\n\r\n    plugins: {\r\n      datalabels: {\r\n        anchor: 'start',\r\n        align: 'start',\r\n        color: '#4e4e4e',\r\n        textAlign:'center',\r\n        display: 'auto',\r\n\r\n        font: {\r\n          size: 16,\r\n          weight: 'bold',\r\n        },\r\n\r\n        formatter: (value, context) => {\r\n          return this.doughnutChartLabels[context.dataIndex];\r\n        },\r\n      },\r\n    },\r\n  }\r\n\r\n  chartPlugins = [ pluginDataLabels ];\r\n\r\n\r\n  constructor(private currencyDisplayPipe: RoundCurrencyPipe) {}\r\n\r\n  ngOnChanges() {\r\n    \r\n    this.jurisdictionComplete = this.jurisdiction;\r\n    this.jurisdictionComplete += (this.jurisdictionSuffix) ? ` ${this.jurisdictionSuffix}` : '';\r\n    \r\n    this.title = `In vs. Out of ${this.jurisdictionComplete}`;\r\n    this.tooltipText = `Total campaign funds raised in the ${this.areaName} versus funds raised outside of city limits.`;\r\n    \r\n    this.doughnutChartData[0].data = [this.inside, this.outside];\r\n\r\n    this.doughnutChartLabels = [\r\n      `In\\n$${this.mNumberFormatter(this.inside)}`,\r\n      `Out\\n$${this.mNumberFormatter(this.outside)}`\r\n    ];\r\n\r\n  }\r\n\r\n  mNumberFormatter(num: number) {\r\n    return this.currencyDisplayPipe.transform(num, 1, '10000');\r\n  }\r\n\r\n}\r\n",
+            "assetsDirs": [],
+            "styleUrlsData": [
+                {
+                    "data": "@import \"../../styles/variables\";\r\n@import \"../../styles/elements\";\r\n@import \"~@fortawesome/fontawesome-free/css/all.min.css\";\r\n\r\ni {\r\n    cursor: pointer;\r\n}\r\n\r\n.title {\r\n    padding: 0;\r\n    font-size: 18px;\r\n    font-weight: bold;\r\n    color: $vvdarkblue;\r\n}\r\n\r\n.chart-container{\r\n    position: relative; \r\n    height:20vh; \r\n    width:20vw;\r\n    margin:auto;\r\n}\r\n\r\n.helper-tip {\r\n    color: $vvgrey;\r\n    font-size: 10px;\r\n}\r\n\r\n\r\n// Expanded Card Adjustments for Smaller Screens\r\n@media only screen and (max-width: 1200px) {\r\n   .in-out-district{\r\n       margin-bottom:40px;\r\n   }\r\n   .chart-container{\r\n        height:20vh !important; \r\n        width:60vw !important;\r\n    }\r\n    .chart-container-raised{\r\n        height:25vh !important; \r\n        width:60vw !important;  \r\n    } \r\n}\r\n\r\n::ng-deep .mat-tooltip {\r\n    font-size: 16px;\r\n}\r\n",
+                    "styleUrl": "./raised-in-out-donut.component.scss"
+                }
+            ],
+            "stylesData": "",
+            "constructorObj": {
+                "name": "constructor",
+                "description": "",
+                "args": [
+                    {
+                        "name": "currencyDisplayPipe",
+                        "type": "RoundCurrencyPipe"
+                    }
+                ],
+                "line": 76,
+                "jsdoctags": [
+                    {
+                        "name": "currencyDisplayPipe",
+                        "type": "RoundCurrencyPipe",
+                        "tagName": {
+                            "text": "param"
+                        }
+                    }
+                ]
+            },
+            "implements": [
+                "OnChanges"
+            ],
+            "templateData": "<div class=\"in-out-district\">\r\n\r\n  <div class=\"title\">\r\n    <p> {{title}}\r\n      <sup>\r\n        <i\r\n        class=\"helper-tip fa fa-question-circle\"\r\n        aria-hidden=\"true\"\r\n        [matTooltip]=\"tooltipText\"\r\n        > </i>\r\n      </sup>\r\n    </p>\r\n  </div>\r\n\r\n  <div class=\"chart-container\">\r\n    <canvas #canvas baseChart \r\n      width=\"260\" \r\n      height=\"260\"\r\n      [chartType]=\"doughnutChartType\"\r\n      [datasets]=\"doughnutChartData\"      \r\n      [options]=\"doughnutChartOptions\"\r\n      [colors]=\"doughnutChartColors\"\r\n      [plugins]=\"chartPlugins\"\r\n    > </canvas>\r\n  </div> \r\n</div>\r\n"
+        },
+        {
             "name": "SplashComponent",
             "id": "component-SplashComponent-ef14843ad9988f25fbc3a8177783b1cf",
             "file": "src/app/components/splash/splash.component.ts",
@@ -2409,12 +2656,77 @@
     "miscellaneous": {
         "variables": [
             {
+                "name": "AmountOver999",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "src/app/vv-charts/raised-in-out-donut/raised-in-out-donut.component.stories.ts",
+                "type": "",
+                "defaultValue": "Template.bind({})"
+            },
+            {
+                "name": "AmountOver9999",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "src/app/vv-charts/raised-in-out-donut/raised-in-out-donut.component.stories.ts",
+                "type": "",
+                "defaultValue": "Template.bind({})"
+            },
+            {
+                "name": "AmountOver99999",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "src/app/vv-charts/raised-in-out-donut/raised-in-out-donut.component.stories.ts",
+                "type": "",
+                "defaultValue": "Template.bind({})"
+            },
+            {
+                "name": "AmountOver999999",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "src/app/vv-charts/raised-in-out-donut/raised-in-out-donut.component.stories.ts",
+                "type": "",
+                "defaultValue": "Template.bind({})"
+            },
+            {
+                "name": "AmountsUnder1000",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "src/app/vv-charts/raised-in-out-donut/raised-in-out-donut.component.stories.ts",
+                "type": "",
+                "defaultValue": "Template.bind({})"
+            },
+            {
+                "name": "CheckCityNameInTooltip",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "src/app/vv-charts/raised-in-out-donut/raised-in-out-donut.component.stories.ts",
+                "type": "",
+                "defaultValue": "Template.bind({})"
+            },
+            {
+                "name": "CityNoSuffix",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "src/app/vv-charts/raised-in-out-donut/raised-in-out-donut.component.stories.ts",
+                "type": "",
+                "defaultValue": "Template.bind({})"
+            },
+            {
                 "name": "context",
                 "ctype": "miscellaneous",
                 "subtype": "variable",
                 "file": "src/test.ts",
                 "type": "",
                 "defaultValue": "require.context('./', true, /\\.spec\\.ts$/)"
+            },
+            {
+                "name": "DistrictWithSuffix",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "src/app/vv-charts/raised-in-out-donut/raised-in-out-donut.component.stories.ts",
+                "type": "",
+                "defaultValue": "Template.bind({})",
+                "description": "<p>Each of the named exports below is a what Storybook calls a story. \nThese are like test cases. Each will show up under the title in the\ndefault export above. </p>\n<p>Each story below reuses the Template above</p>\n"
             },
             {
                 "name": "environment",
@@ -2433,6 +2745,46 @@
                 "defaultValue": "{\r\n  production: false\r\n}"
             },
             {
+                "name": "EqualInAndOut",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "src/app/vv-charts/raised-in-out-donut/raised-in-out-donut.component.stories.ts",
+                "type": "",
+                "defaultValue": "Template.bind({})"
+            },
+            {
+                "name": "HighInsideLowOutside",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "src/app/vv-charts/raised-in-out-donut/raised-in-out-donut.component.stories.ts",
+                "type": "",
+                "defaultValue": "Template.bind({})"
+            },
+            {
+                "name": "LargeDifferenceFavoringInside",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "src/app/vv-charts/raised-in-out-donut/raised-in-out-donut.component.stories.ts",
+                "type": "",
+                "defaultValue": "Template.bind({})"
+            },
+            {
+                "name": "LargeDifferenceFavoringOutside",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "src/app/vv-charts/raised-in-out-donut/raised-in-out-donut.component.stories.ts",
+                "type": "",
+                "defaultValue": "Template.bind({})"
+            },
+            {
+                "name": "LowInsideHighOutside",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "src/app/vv-charts/raised-in-out-donut/raised-in-out-donut.component.stories.ts",
+                "type": "",
+                "defaultValue": "Template.bind({})"
+            },
+            {
                 "name": "placeholder_data",
                 "ctype": "miscellaneous",
                 "subtype": "variable",
@@ -2446,12 +2798,137 @@
                 "subtype": "variable",
                 "file": "src/test.ts",
                 "type": "any"
+            },
+            {
+                "name": "Template",
+                "ctype": "miscellaneous",
+                "subtype": "variable",
+                "file": "src/app/vv-charts/raised-in-out-donut/raised-in-out-donut.component.stories.ts",
+                "type": "Story<RaisedInOutDonutComponent>",
+                "defaultValue": "(args: RaisedInOutDonutComponent) => ({\r\n  component: RaisedInOutDonutComponent,\r\n  moduleMetadata: {\r\n    declarations: [],\r\n    imports: [BrowserAnimationsModule, ChartsModule, MatTooltipModule],\r\n    providers: [RoundCurrencyPipe],\r\n  },\r\n  props: args,\r\n})",
+                "description": "<p>imports: for dependencies that would usually be provided in the module containing the component\nproviders: for component dependencies</p>\n<p>The same template is used for the component stories below it.</p>\n"
             }
         ],
         "functions": [],
         "typealiases": [],
         "enumerations": [],
         "groupedVariables": {
+            "src/app/vv-charts/raised-in-out-donut/raised-in-out-donut.component.stories.ts": [
+                {
+                    "name": "AmountOver999",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "src/app/vv-charts/raised-in-out-donut/raised-in-out-donut.component.stories.ts",
+                    "type": "",
+                    "defaultValue": "Template.bind({})"
+                },
+                {
+                    "name": "AmountOver9999",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "src/app/vv-charts/raised-in-out-donut/raised-in-out-donut.component.stories.ts",
+                    "type": "",
+                    "defaultValue": "Template.bind({})"
+                },
+                {
+                    "name": "AmountOver99999",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "src/app/vv-charts/raised-in-out-donut/raised-in-out-donut.component.stories.ts",
+                    "type": "",
+                    "defaultValue": "Template.bind({})"
+                },
+                {
+                    "name": "AmountOver999999",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "src/app/vv-charts/raised-in-out-donut/raised-in-out-donut.component.stories.ts",
+                    "type": "",
+                    "defaultValue": "Template.bind({})"
+                },
+                {
+                    "name": "AmountsUnder1000",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "src/app/vv-charts/raised-in-out-donut/raised-in-out-donut.component.stories.ts",
+                    "type": "",
+                    "defaultValue": "Template.bind({})"
+                },
+                {
+                    "name": "CheckCityNameInTooltip",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "src/app/vv-charts/raised-in-out-donut/raised-in-out-donut.component.stories.ts",
+                    "type": "",
+                    "defaultValue": "Template.bind({})"
+                },
+                {
+                    "name": "CityNoSuffix",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "src/app/vv-charts/raised-in-out-donut/raised-in-out-donut.component.stories.ts",
+                    "type": "",
+                    "defaultValue": "Template.bind({})"
+                },
+                {
+                    "name": "DistrictWithSuffix",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "src/app/vv-charts/raised-in-out-donut/raised-in-out-donut.component.stories.ts",
+                    "type": "",
+                    "defaultValue": "Template.bind({})",
+                    "description": "<p>Each of the named exports below is a what Storybook calls a story. \nThese are like test cases. Each will show up under the title in the\ndefault export above. </p>\n<p>Each story below reuses the Template above</p>\n"
+                },
+                {
+                    "name": "EqualInAndOut",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "src/app/vv-charts/raised-in-out-donut/raised-in-out-donut.component.stories.ts",
+                    "type": "",
+                    "defaultValue": "Template.bind({})"
+                },
+                {
+                    "name": "HighInsideLowOutside",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "src/app/vv-charts/raised-in-out-donut/raised-in-out-donut.component.stories.ts",
+                    "type": "",
+                    "defaultValue": "Template.bind({})"
+                },
+                {
+                    "name": "LargeDifferenceFavoringInside",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "src/app/vv-charts/raised-in-out-donut/raised-in-out-donut.component.stories.ts",
+                    "type": "",
+                    "defaultValue": "Template.bind({})"
+                },
+                {
+                    "name": "LargeDifferenceFavoringOutside",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "src/app/vv-charts/raised-in-out-donut/raised-in-out-donut.component.stories.ts",
+                    "type": "",
+                    "defaultValue": "Template.bind({})"
+                },
+                {
+                    "name": "LowInsideHighOutside",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "src/app/vv-charts/raised-in-out-donut/raised-in-out-donut.component.stories.ts",
+                    "type": "",
+                    "defaultValue": "Template.bind({})"
+                },
+                {
+                    "name": "Template",
+                    "ctype": "miscellaneous",
+                    "subtype": "variable",
+                    "file": "src/app/vv-charts/raised-in-out-donut/raised-in-out-donut.component.stories.ts",
+                    "type": "Story<RaisedInOutDonutComponent>",
+                    "defaultValue": "(args: RaisedInOutDonutComponent) => ({\r\n  component: RaisedInOutDonutComponent,\r\n  moduleMetadata: {\r\n    declarations: [],\r\n    imports: [BrowserAnimationsModule, ChartsModule, MatTooltipModule],\r\n    providers: [RoundCurrencyPipe],\r\n  },\r\n  props: args,\r\n})",
+                    "description": "<p>imports: for dependencies that would usually be provided in the module containing the component\nproviders: for component dependencies</p>\n<p>The same template is used for the component stories below it.</p>\n"
+                }
+            ],
             "src/test.ts": [
                 {
                     "name": "context",
@@ -2553,7 +3030,7 @@
         ]
     },
     "coverage": {
-        "count": 0,
+        "count": 4,
         "status": "low",
         "files": [
             {
@@ -2744,6 +3221,164 @@
                 "name": "SidenavService",
                 "coveragePercent": 0,
                 "coverageCount": "0/11",
+                "status": "low"
+            },
+            {
+                "filePath": "src/app/vv-charts/raised-in-out-donut/raised-in-out-donut.component.stories.ts",
+                "type": "variable",
+                "linktype": "miscellaneous",
+                "linksubtype": "variable",
+                "name": "AmountOver999",
+                "coveragePercent": 0,
+                "coverageCount": "0/1",
+                "status": "low"
+            },
+            {
+                "filePath": "src/app/vv-charts/raised-in-out-donut/raised-in-out-donut.component.stories.ts",
+                "type": "variable",
+                "linktype": "miscellaneous",
+                "linksubtype": "variable",
+                "name": "AmountOver9999",
+                "coveragePercent": 0,
+                "coverageCount": "0/1",
+                "status": "low"
+            },
+            {
+                "filePath": "src/app/vv-charts/raised-in-out-donut/raised-in-out-donut.component.stories.ts",
+                "type": "variable",
+                "linktype": "miscellaneous",
+                "linksubtype": "variable",
+                "name": "AmountOver99999",
+                "coveragePercent": 0,
+                "coverageCount": "0/1",
+                "status": "low"
+            },
+            {
+                "filePath": "src/app/vv-charts/raised-in-out-donut/raised-in-out-donut.component.stories.ts",
+                "type": "variable",
+                "linktype": "miscellaneous",
+                "linksubtype": "variable",
+                "name": "AmountOver999999",
+                "coveragePercent": 0,
+                "coverageCount": "0/1",
+                "status": "low"
+            },
+            {
+                "filePath": "src/app/vv-charts/raised-in-out-donut/raised-in-out-donut.component.stories.ts",
+                "type": "variable",
+                "linktype": "miscellaneous",
+                "linksubtype": "variable",
+                "name": "AmountsUnder1000",
+                "coveragePercent": 0,
+                "coverageCount": "0/1",
+                "status": "low"
+            },
+            {
+                "filePath": "src/app/vv-charts/raised-in-out-donut/raised-in-out-donut.component.stories.ts",
+                "type": "variable",
+                "linktype": "miscellaneous",
+                "linksubtype": "variable",
+                "name": "CheckCityNameInTooltip",
+                "coveragePercent": 0,
+                "coverageCount": "0/1",
+                "status": "low"
+            },
+            {
+                "filePath": "src/app/vv-charts/raised-in-out-donut/raised-in-out-donut.component.stories.ts",
+                "type": "variable",
+                "linktype": "miscellaneous",
+                "linksubtype": "variable",
+                "name": "CityNoSuffix",
+                "coveragePercent": 0,
+                "coverageCount": "0/1",
+                "status": "low"
+            },
+            {
+                "filePath": "src/app/vv-charts/raised-in-out-donut/raised-in-out-donut.component.stories.ts",
+                "type": "variable",
+                "linktype": "miscellaneous",
+                "linksubtype": "variable",
+                "name": "DistrictWithSuffix",
+                "coveragePercent": 100,
+                "coverageCount": "1/1",
+                "status": "very-good"
+            },
+            {
+                "filePath": "src/app/vv-charts/raised-in-out-donut/raised-in-out-donut.component.stories.ts",
+                "type": "variable",
+                "linktype": "miscellaneous",
+                "linksubtype": "variable",
+                "name": "EqualInAndOut",
+                "coveragePercent": 0,
+                "coverageCount": "0/1",
+                "status": "low"
+            },
+            {
+                "filePath": "src/app/vv-charts/raised-in-out-donut/raised-in-out-donut.component.stories.ts",
+                "type": "variable",
+                "linktype": "miscellaneous",
+                "linksubtype": "variable",
+                "name": "HighInsideLowOutside",
+                "coveragePercent": 0,
+                "coverageCount": "0/1",
+                "status": "low"
+            },
+            {
+                "filePath": "src/app/vv-charts/raised-in-out-donut/raised-in-out-donut.component.stories.ts",
+                "type": "variable",
+                "linktype": "miscellaneous",
+                "linksubtype": "variable",
+                "name": "LargeDifferenceFavoringInside",
+                "coveragePercent": 0,
+                "coverageCount": "0/1",
+                "status": "low"
+            },
+            {
+                "filePath": "src/app/vv-charts/raised-in-out-donut/raised-in-out-donut.component.stories.ts",
+                "type": "variable",
+                "linktype": "miscellaneous",
+                "linksubtype": "variable",
+                "name": "LargeDifferenceFavoringOutside",
+                "coveragePercent": 0,
+                "coverageCount": "0/1",
+                "status": "low"
+            },
+            {
+                "filePath": "src/app/vv-charts/raised-in-out-donut/raised-in-out-donut.component.stories.ts",
+                "type": "variable",
+                "linktype": "miscellaneous",
+                "linksubtype": "variable",
+                "name": "LowInsideHighOutside",
+                "coveragePercent": 0,
+                "coverageCount": "0/1",
+                "status": "low"
+            },
+            {
+                "filePath": "src/app/vv-charts/raised-in-out-donut/raised-in-out-donut.component.stories.ts",
+                "type": "variable",
+                "linktype": "miscellaneous",
+                "linksubtype": "variable",
+                "name": "Template",
+                "coveragePercent": 100,
+                "coverageCount": "1/1",
+                "status": "very-good"
+            },
+            {
+                "filePath": "src/app/vv-charts/raised-in-out-donut/raised-in-out-donut.component.ts",
+                "type": "component",
+                "linktype": "component",
+                "name": "RaisedInOutDonutComponent",
+                "coveragePercent": 0,
+                "coverageCount": "0/18",
+                "status": "low"
+            },
+            {
+                "filePath": "src/app/vv-charts/round-currency.pipe.ts",
+                "type": "pipe",
+                "linktype": "pipe",
+                "name": "RoundCurrencyPipe",
+                "coveragePercent": 0,
+                "coverageCount": "0/1",
                 "status": "low"
             },
             {

--- a/src/app/vv-charts/raised-in-out-donut/raised-in-out-donut.component.html
+++ b/src/app/vv-charts/raised-in-out-donut/raised-in-out-donut.component.html
@@ -1,0 +1,26 @@
+<div class="in-out-district">
+
+  <div class="title">
+    <p> {{title}}
+      <sup>
+        <i
+        class="helper-tip fa fa-question-circle"
+        aria-hidden="true"
+        [matTooltip]="tooltipText"
+        > </i>
+      </sup>
+    </p>
+  </div>
+
+  <div class="chart-container">
+    <canvas #canvas baseChart 
+      width="260" 
+      height="260"
+      [chartType]="doughnutChartType"
+      [datasets]="doughnutChartData"      
+      [options]="doughnutChartOptions"
+      [colors]="doughnutChartColors"
+      [plugins]="chartPlugins"
+    > </canvas>
+  </div> 
+</div>

--- a/src/app/vv-charts/raised-in-out-donut/raised-in-out-donut.component.scss
+++ b/src/app/vv-charts/raised-in-out-donut/raised-in-out-donut.component.scss
@@ -1,0 +1,46 @@
+@import "../../styles/variables";
+@import "../../styles/elements";
+@import "~@fortawesome/fontawesome-free/css/all.min.css";
+
+i {
+    cursor: pointer;
+}
+
+.title {
+    padding: 0;
+    font-size: 18px;
+    font-weight: bold;
+    color: $vvdarkblue;
+}
+
+.chart-container{
+    position: relative; 
+    height:20vh; 
+    width:20vw;
+    margin:auto;
+}
+
+.helper-tip {
+    color: $vvgrey;
+    font-size: 10px;
+}
+
+
+// Expanded Card Adjustments for Smaller Screens
+@media only screen and (max-width: 1200px) {
+   .in-out-district{
+       margin-bottom:40px;
+   }
+   .chart-container{
+        height:20vh !important; 
+        width:60vw !important;
+    }
+    .chart-container-raised{
+        height:25vh !important; 
+        width:60vw !important;  
+    } 
+}
+
+::ng-deep .mat-tooltip {
+    font-size: 16px;
+}

--- a/src/app/vv-charts/raised-in-out-donut/raised-in-out-donut.component.stories.ts
+++ b/src/app/vv-charts/raised-in-out-donut/raised-in-out-donut.component.stories.ts
@@ -1,0 +1,174 @@
+import { Meta, Story } from '@storybook/angular';
+
+import { RaisedInOutDonutComponent } from './raised-in-out-donut.component'; // component being tested
+import { RoundCurrencyPipe } from '../round-currency.pipe'; // component dependency
+
+import { ChartsModule } from 'ng2-charts';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { MatTooltipModule } from '@angular/material/tooltip';
+
+/**
+ * This file can be used as a template to copy and then customize to test a component. The 
+ * component does not need to be part of a module to test in Storybook. This .stories.ts file 
+ * should be located in the same folder as the component but it can be located elsewhere if needed.
+ * 
+ * To customize change the .component import line above to the component to test.
+ * Then change all references to that component below. Modify the title and argTypes in the 
+ * default export. Update the template if needed. Remove all but one of the stores (named exports).
+ * Customize the remaining story then duplicate the story for each test case. The Controls setup 
+ * by the argTypes can be used in place of some tests since they allow for live changes to @Inputs.
+ * 
+ * Use 'npm run storybook' to start Storybook at localhost:6006
+ */
+
+
+/**
+ * export default: required for each component 
+ * title: shows in Storybook component list as heading/expanded list
+ * argTypes: used to customize the type of controls at the bottom of Storybook
+ *   names should match the component @Inputs
+ * 
+ * Controls allow the inputs to be changed from within the Storybook UI
+ */
+export default {
+  title: 'Charts/In vs. Out raised funds',
+  component: RaisedInOutDonutComponent,
+  argTypes: {
+    inside: { control: 'number' },
+    outside: { control: 'number' },
+    jurisdiction: { control: 'text' },
+    jurisdictionSuffix: { control: 'text' },
+    areaName: { control: 'text' },
+  },
+} as Meta;
+
+
+/**
+ * imports: for dependencies that would usually be provided in the module containing the component
+ * providers: for component dependencies
+ * 
+ * The same template is used for the component stories below it.
+ */
+const Template: Story<RaisedInOutDonutComponent> = (args: RaisedInOutDonutComponent) => ({
+  component: RaisedInOutDonutComponent,
+  moduleMetadata: {
+    declarations: [],
+    imports: [BrowserAnimationsModule, ChartsModule, MatTooltipModule],
+    providers: [RoundCurrencyPipe],
+  },
+  props: args,
+})
+
+/**
+ * Each of the named exports below is a what Storybook calls a story. 
+ * These are like test cases. Each will show up under the title in the
+ * default export above. 
+ * 
+ * Each story below reuses the Template above
+ */
+export const DistrictWithSuffix = Template.bind({});
+DistrictWithSuffix.args = {
+  // The args you need here will depend on your component
+  // Each will be passed to a corresponding component input  
+  inside: 1000,
+  outside: 5000,
+  jurisdiction: 'District',
+  jurisdictionSuffix: '1',
+  areaName: 'San Diego City',
+}
+
+export const CityNoSuffix = Template.bind({});
+CityNoSuffix.args = {
+  inside: 1000,
+  outside: 5000,
+  jurisdiction: 'City',
+  areaName: 'San Diego City',
+}
+
+export const CheckCityNameInTooltip = Template.bind({});
+CheckCityNameInTooltip.args = {
+  inside: 3000,
+  outside: 5000,
+  jurisdiction: 'City',
+  areaName: 'Special Tooltip City',
+}
+
+export const EqualInAndOut = Template.bind({});
+EqualInAndOut.args = {
+  inside: 1234,
+  outside: 1234,
+  jurisdiction: 'City',
+  areaName: 'San Diego City,'
+};
+
+export const HighInsideLowOutside = Template.bind({});
+HighInsideLowOutside.args = {
+  inside: 20000,
+  outside: 4000,
+  jurisdiction: 'City',
+  areaName: 'San Diego City',
+}
+
+export const LowInsideHighOutside = Template.bind({});
+LowInsideHighOutside.args = {
+  inside: 2000,
+  outside: 12000,
+  jurisdiction: 'City',
+  areaName: 'San Diego City',
+}
+
+export const LargeDifferenceFavoringInside = Template.bind({});
+LargeDifferenceFavoringInside.args = {
+  inside: 210,
+  outside: 4,
+  jurisdiction: 'City',
+  areaName: 'San Diego City',
+}
+
+export const LargeDifferenceFavoringOutside = Template.bind({});
+LargeDifferenceFavoringOutside.args = {
+  inside: 7,
+  outside: 190,
+  jurisdiction: 'City',
+  areaName: 'San Diego City',
+}
+
+export const AmountsUnder1000 = Template.bind({});
+AmountsUnder1000.args = {
+  inside: 800,
+  outside: 500,
+  jurisdiction: 'City',
+  areaName: 'San Diego City',
+}
+
+export const AmountOver999 = Template.bind({});
+AmountOver999.args = {
+  inside: 1000,
+  outside: 1500,
+  jurisdiction: 'City',
+  areaName: 'San Diego City',
+}
+
+export const AmountOver9999 = Template.bind({});
+AmountOver9999.args = {
+  inside: 10000,
+  outside: 15000,
+  jurisdiction: 'City',
+  areaName: 'San Diego City',
+}
+
+export const AmountOver99999 = Template.bind({});
+AmountOver99999.args = {
+  inside: 100000,
+  outside: 150000,
+  jurisdiction: 'City',
+  areaName: 'San Diego City',
+}
+
+export const AmountOver999999 = Template.bind({});
+AmountOver999999.args = {
+  inside: 1000000,
+  outside: 1300000,
+  jurisdiction: 'City',
+  areaName: 'San Diego City',
+}

--- a/src/app/vv-charts/raised-in-out-donut/raised-in-out-donut.component.ts
+++ b/src/app/vv-charts/raised-in-out-donut/raised-in-out-donut.component.ts
@@ -1,0 +1,102 @@
+import { Component, OnChanges, Input } from '@angular/core';
+
+import * as pluginDataLabels from 'chartjs-plugin-datalabels';
+import { ChartOptions, ChartType, ChartDataSets } from 'chart.js';
+import { Color, Label } from 'ng2-charts';
+
+import { RoundCurrencyPipe } from '../round-currency.pipe'
+
+@Component({
+  selector: 'raised-in-out-donut',
+  templateUrl: './raised-in-out-donut.component.html',
+  styleUrls: ['./raised-in-out-donut.component.scss'],
+})
+export class RaisedInOutDonutComponent implements OnChanges {
+  @Input() inside: number;
+  @Input() outside: number;
+  @Input() areaName: string; // Example: City of San Diego
+  @Input() jurisdiction: string; // Example: City, District
+  @Input() jurisdictionSuffix?: string; // Example '1', '5'
+
+
+  title: string;
+  tooltipText: string;
+  jurisdictionComplete: string;
+
+
+  doughnutChartType: ChartType = 'doughnut';
+  doughnutChartData: ChartDataSets[] = [{
+    data: [1,1],
+  }];
+  
+  doughnutChartLabels: Label[];
+
+
+  doughnutChartColors: Color[] = [
+    { backgroundColor: ['#3392ff', '#bfd63b'] },
+  ];
+
+  doughnutChartOptions: ChartOptions = {
+    // responsive: true,
+    responsive: false,
+    maintainAspectRatio: false,
+    cutoutPercentage: 60,
+    animation: {
+      animateRotate: true,
+    },
+
+    legend: {
+      display: false,
+    },
+
+    tooltips: {
+      enabled: false,
+    },
+
+    plugins: {
+      datalabels: {
+        anchor: 'start',
+        align: 'start',
+        color: '#4e4e4e',
+        textAlign:'center',
+        display: 'auto',
+
+        font: {
+          size: 16,
+          weight: 'bold',
+        },
+
+        formatter: (value, context) => {
+          return this.doughnutChartLabels[context.dataIndex];
+        },
+      },
+    },
+  }
+
+  chartPlugins = [ pluginDataLabels ];
+
+
+  constructor(private currencyDisplayPipe: RoundCurrencyPipe) {}
+
+  ngOnChanges() {
+    
+    this.jurisdictionComplete = this.jurisdiction;
+    this.jurisdictionComplete += (this.jurisdictionSuffix) ? ` ${this.jurisdictionSuffix}` : '';
+    
+    this.title = `In vs. Out of ${this.jurisdictionComplete}`;
+    this.tooltipText = `Total campaign funds raised in the ${this.areaName} versus funds raised outside of city limits.`;
+    
+    this.doughnutChartData[0].data = [this.inside, this.outside];
+
+    this.doughnutChartLabels = [
+      `In\n$${this.mNumberFormatter(this.inside)}`,
+      `Out\n$${this.mNumberFormatter(this.outside)}`
+    ];
+
+  }
+
+  mNumberFormatter(num: number) {
+    return this.currencyDisplayPipe.transform(num, 1, '10000');
+  }
+
+}

--- a/src/app/vv-charts/round-currency.pipe.ts
+++ b/src/app/vv-charts/round-currency.pipe.ts
@@ -1,0 +1,26 @@
+import { Pipe, PipeTransform } from "@angular/core";
+
+@Pipe({
+  name: "roundCurrency",
+})
+export class RoundCurrencyPipe implements PipeTransform {
+  transform(input: any, args?: any, threshold?: any): any {
+    var exp,
+      oneMillion = 1000000,
+      minimum = Number.isNaN(threshold) ? oneMillion : Number(threshold),
+      suffixes = ["k", "M", "G", "T", "P", "E"];
+
+    if (Number.isNaN(input)) {
+      return null;
+    }
+ 
+    // if (input < oneMillion) {
+    if (input < minimum || input < 1000) {
+      return Number(input).toLocaleString('en-US');
+    }
+
+    exp = Math.floor(Math.log(input) / Math.log(1000));
+
+    return (input / Math.pow(1000, exp)).toFixed(args) + suffixes[exp - 1];
+  }
+}


### PR DESCRIPTION
Added a standalone component for the inside vs. outside spending doughnut chart. This includes a .component.stories.ts file to be used with Storybook to test the component. The .component.stories.ts file includes some basic instructions on how to use a copy of the file for working on other components.

This component still needs some work on adapting the .scss file to match the existing style from the integrated chart in candidate-card-expanded.component. Also, the title needs to be centered and the size needs to be more adaptive to its context.

![chrome_2021-01-19_00-35-19](https://user-images.githubusercontent.com/1051611/105008526-36b74100-59ee-11eb-9753-253f0c720664.png)

Closes #142