### PR TITLE
candidate navigation component

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -27,6 +27,8 @@ import { CityCouncilDistrictComponent } from './components/city-council-district
 import { RoundCurrencyDisplayPipe } from './pipes/round-currency-display.pipe';
 import { VvChartsModule } from './vv-charts/vv-charts.module';
 
+import { CandidateNavigationComponent } from './components/candidate-navigation/candidate-navigation.component';
+
 @NgModule({
   exports: [
     MatExpansionModule,
@@ -44,6 +46,7 @@ import { VvChartsModule } from './vv-charts/vv-charts.module';
     AboutComponent,
     CityCouncilDistrictComponent,
     RoundCurrencyDisplayPipe,
+    CandidateNavigationComponent,
   ],
   imports: [
     BrowserModule,

--- a/src/app/components/candidate-navigation/candidate-navigation.component.html
+++ b/src/app/components/candidate-navigation/candidate-navigation.component.html
@@ -1,0 +1,72 @@
+<mat-nav-list [disableRipple]="true">
+  <mat-accordion displayMode="flat" class="candidate-navigation">
+
+    <ng-container *ngFor="let office of offices;">
+
+      <mat-expansion-panel
+        hideToggle="true"  
+        (opened)="setSelectedOffice(office.title)" 
+      >
+
+        <mat-expansion-panel-header 
+          collapsedHeight="50px" 
+          expandedHeight="50px"
+          [ngClass]="{'active-link':office.title.toUpperCase() === selectedOffice.toUpperCase()}"
+        >
+          <mat-panel-title>
+            <a routerLink="{{office.route}}" routerLinkActive="active">{{office.title}}</a>
+          </mat-panel-title>
+        </mat-expansion-panel-header>
+
+
+        <ng-container *ngIf="office.hasSeats; else elseNonSeatOffice">
+          <mat-expansion-panel 
+            *ngFor="let seat of office.seats;" 
+            [expanded]="selectedSeatName === seat.title"
+            (opened)="setSelectedSeat(seat.title)"
+            class="mat-elevation-z0"
+          >
+          
+            <mat-expansion-panel-header 
+              collapsedHeight="30px" 
+              expandedHeight="30px"
+              [ngClass]="{ 'district-selected': selectedSeatName === seat.title }"
+            >
+              <a routerLink="{{seat.route}}" routerLinkActive="active">
+                {{seat.title}}
+              </a>
+            </mat-expansion-panel-header>
+
+            <ng-container *ngTemplateOutlet="candidatesT; context: {office: seat}">
+            </ng-container>
+
+          </mat-expansion-panel>         
+        </ng-container>
+
+        <ng-template #elseNonSeatOffice>
+          <ng-container *ngTemplateOutlet="candidatesT; context: {office: office}">
+          </ng-container>
+        </ng-template>
+
+      </mat-expansion-panel>
+    </ng-container>
+  </mat-accordion>
+</mat-nav-list>
+
+
+<ng-template #candidatesT let-office="office">
+  <div class="candidates">
+    <ul *ngFor="let candidate of office.candidates;" class="candidate-name">
+      <li>
+        <a 
+          routerLinkActive="active"
+          routerLink="{{candidate.routeLink}}" 
+          [ngClass]="{ 'candidate-selected': selectedCandidateId === candidate.id }"
+          (click)="setSelectedCandidate(candidate.id)"
+        >
+          {{candidate.fullName}}
+        </a>
+      </li>
+    </ul>
+  </div>
+</ng-template>

--- a/src/app/components/candidate-navigation/candidate-navigation.component.ts
+++ b/src/app/components/candidate-navigation/candidate-navigation.component.ts
@@ -1,0 +1,94 @@
+import { Component, OnInit } from '@angular/core';
+import { toArray } from 'rxjs/operators';
+
+import { CandidateNavigation } from '../../interfaces/candidateNavigation'
+import { CandidateDataService } from '../../services/candidate-data.service';
+
+interface CandidateNavigationWithRoute extends CandidateNavigation {
+  routeLink: string;
+}
+
+@Component({
+  selector: 'app-candidate-navigation',
+  templateUrl: './candidate-navigation.component.html',
+})
+export class CandidateNavigationComponent implements OnInit {
+  offices = [];
+  selectedOffice: string = '';
+  selectedSeatName: string = '';
+  selectedCandidateId: string = '';
+  seatType: string = 'District';
+
+  constructor(
+    private candidateDataService: CandidateDataService ) { }
+
+  addRoute(candidate: CandidateNavigation): CandidateNavigationWithRoute {
+    let path = `${candidate.officeType}`;
+
+    if (candidate.seat !== null) {
+      path += `_${candidate.seat.type}-${candidate.seat.name}`;
+    }
+
+    return {
+      ...candidate,
+      routeLink: `${path}/${candidate.id}`.toLowerCase().split(' ').join('-'),
+      seat: candidate.seat ? { ...candidate.seat } : null,
+    };
+  }
+
+  ngOnInit(): void {
+    this.candidateDataService.getCandidates().pipe( toArray() ).subscribe(candidates => {
+      const officeTitles: string[] = candidates.map(candidate => candidate.officeType).sort().reverse();
+      const distinctOfficeTitles: string[] = [... new Set(officeTitles)]; // remove duplicates
+      
+      const candidatesWithRoute = candidates.map(candidate => this.addRoute(candidate));
+
+      this.offices = this.getOffices(candidatesWithRoute, distinctOfficeTitles);
+    })
+  }
+
+  getOffices(candidates: CandidateNavigation[], officeTitles: string[]) {
+    const offices = officeTitles.map(officeTitle => {
+      let seatsWithCandidates = null;
+
+      let candidatesForOffice: CandidateNavigation[] = candidates
+        .filter(candidate => candidate.officeType === officeTitle);
+
+      const hasSeats: boolean = candidatesForOffice.some(candidate => candidate.seat !== null);
+
+      if (hasSeats) {
+        const seatNames: string[] = candidatesForOffice.map(candidate => candidate.seat.name);
+
+        const distinctSeatNames: string[] = [... new Set(seatNames)].sort(); // remove duplicates
+        seatsWithCandidates = distinctSeatNames
+          .map(seatName => ({
+            title: `${this.seatType} ${seatName}`,
+            route: `${officeTitle}_${this.seatType}-${seatName}`.toLowerCase().split(' ').join('-'),
+            candidates: candidatesForOffice.filter(candidate => candidate.seat.name === seatName),
+            hasSeats: false,
+            seats: null,
+        }));
+      }
+
+      return {
+        title: officeTitle,
+        route: officeTitle.toLowerCase().split(' ').join('-'),
+        candidates: candidatesForOffice,
+        hasSeats,
+        seats: seatsWithCandidates,
+      }
+    });
+
+    return offices;
+  }
+
+  setSelectedOffice(officeTitle: string) {
+    this.selectedOffice = officeTitle;
+  }
+  setSelectedSeat(seatName: string) {
+    this.selectedSeatName = seatName;
+  }
+  setSelectedCandidate(candidateId: string) {
+    this.selectedCandidateId = candidateId;
+  }
+}


### PR DESCRIPTION
Adds candidate navigation component for the sidenav menu. This uses the candidate-data.service rather than accepting the candidate data as input.

Know issues: This component does not use its own CSS/SCSS but depends on the styles set in the parent Home component.

Component is not currently active in the site. When it is it used it will replace the contents inside of the <mat-drawer> element in the Home component template. The routing may need to be updated when this component is added to the Home component template.

Closes #252