### PR TITLE
added expanded-chart-title component

### DIFF
--- a/src/app/candidate-quick-view/candidate-quick-view.module.ts
+++ b/src/app/candidate-quick-view/candidate-quick-view.module.ts
@@ -6,9 +6,11 @@ import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
 
 import { VvChartsModule } from '../vv-charts/vv-charts.module';
 
+import { ExpandedChartTitleComponent } from './expanded-chart-title/expanded-chart-title.component';
 
 @NgModule({
   declarations: [
+    ExpandedChartTitleComponent,
   ],
   imports: [
     CommonModule,

--- a/src/app/candidate-quick-view/expanded-chart-title/expanded-chart-title.component.html
+++ b/src/app/candidate-quick-view/expanded-chart-title/expanded-chart-title.component.html
@@ -1,0 +1,17 @@
+
+<div class="title" >
+
+  <p>
+    <span class="text" [style.color]="textColor">{{titleText}}</span>
+    <span 
+      matTooltipClass="tooltip-text"
+      aria-hidden="true"
+      [matTooltip]="tooltipText" 
+    >    
+      <sup [style.color]="tooltipColor" class="tooltip-icon">
+        <i><fa-icon [icon]="faQuestionCircle"></fa-icon></i>
+      </sup>
+   </span> 
+  </p>
+  
+</div>

--- a/src/app/candidate-quick-view/expanded-chart-title/expanded-chart-title.component.scss
+++ b/src/app/candidate-quick-view/expanded-chart-title/expanded-chart-title.component.scss
@@ -1,0 +1,20 @@
+.title {
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  
+  .text {
+    font-size: 18px;
+    font-weight: bold;
+  }
+
+  .tooltip-icon {
+    cursor: pointer;
+    padding-left: .5em;
+    font-size: 10px;
+  } 
+}
+
+::ng-deep .tooltip-text {
+  font-size: 16px;
+}

--- a/src/app/candidate-quick-view/expanded-chart-title/expanded-chart-title.component.stories.ts
+++ b/src/app/candidate-quick-view/expanded-chart-title/expanded-chart-title.component.stories.ts
@@ -1,0 +1,43 @@
+import { Meta, Story } from '@storybook/angular/types-6-0';
+import { moduleMetadata } from '@storybook/angular';
+
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { MatTooltipModule } from '@angular/material/tooltip';
+import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
+
+import { ExpandedChartTitleComponent } from './expanded-chart-title.component';
+
+export default {
+  title: 'Expanded/Chart Title',
+  component: ExpandedChartTitleComponent,
+  decorators: [
+    moduleMetadata({
+      declarations: [],
+      imports: [
+        BrowserAnimationsModule,
+        FontAwesomeModule,
+        MatTooltipModule,
+      ],
+      providers: [],
+    }),
+  ], 
+  argTypes: { },
+} as Meta;
+
+const Template: Story<ExpandedChartTitleComponent> = (args: ExpandedChartTitleComponent) => ({
+  props: args,
+});
+
+export const Default = Template.bind({});
+Default.args = {
+  titleText: "Chart Title",
+  tooltipText: "Placeholder tooltip text.",
+};
+
+export const GreenText = Template.bind({});
+GreenText.args = {
+  titleText: "Chart Title",
+  textColor: 'green',
+  tooltipText: "Placeholder tooltip text.",
+  tooltipColor: 'green',  
+};

--- a/src/app/candidate-quick-view/expanded-chart-title/expanded-chart-title.component.ts
+++ b/src/app/candidate-quick-view/expanded-chart-title/expanded-chart-title.component.ts
@@ -1,0 +1,21 @@
+import { Component, Input, } from '@angular/core';
+
+import { faQuestionCircle } from '@fortawesome/free-solid-svg-icons';
+
+
+@Component({
+  selector: 'app-expanded-chart-title',
+  templateUrl: './expanded-chart-title.component.html',
+  styleUrls: ['./expanded-chart-title.component.scss']
+})
+export class ExpandedChartTitleComponent {
+  @Input() titleText: string = 'Title Text Here';
+  @Input() textColor: string = '#244366';
+  @Input() tooltipText: string = 'Placeholder text.';
+  @Input() tooltipColor: string = '#707070';
+  
+  faQuestionCircle = faQuestionCircle;
+
+  constructor() { }
+
+}


### PR DESCRIPTION
This can be used by the chart component containers in the expanded card.

![chrome_2021-07-05_16-45-19](https://user-images.githubusercontent.com/1051611/124524566-6b5a6180-ddb0-11eb-86cf-57049edd9e10.png)

With tooltip text showing
![chrome_2021-07-05_16-46-00](https://user-images.githubusercontent.com/1051611/124524585-79a87d80-ddb0-11eb-9b7b-f8b1394d9189.png)
