### PR TITLE
added expanded-outside-money component within Candidate QuickView module

### DIFF
--- a/src/app/candidate-quick-view/candidate-quick-view.module.ts
+++ b/src/app/candidate-quick-view/candidate-quick-view.module.ts
@@ -7,10 +7,12 @@ import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
 import { VvChartsModule } from '../vv-charts/vv-charts.module';
 
 import { ExpandedChartTitleComponent } from './expanded-chart-title/expanded-chart-title.component';
+import { ExpandedOutsideMoneyComponent } from './expanded-outside-money/expanded-outside-money.component';
 
 @NgModule({
   declarations: [
     ExpandedChartTitleComponent,
+    ExpandedOutsideMoneyComponent,
   ],
   imports: [
     CommonModule,
@@ -19,6 +21,7 @@ import { ExpandedChartTitleComponent } from './expanded-chart-title/expanded-cha
     VvChartsModule,
   ],
   exports: [
+    ExpandedOutsideMoneyComponent,
   ],
 })
 export class CandidateQuickViewModule { }

--- a/src/app/candidate-quick-view/expanded-outside-money/expanded-outside-money.component.html
+++ b/src/app/candidate-quick-view/expanded-outside-money/expanded-outside-money.component.html
@@ -1,0 +1,31 @@
+
+<div class="outside-money-container"
+  [style.backgroundColor]="backgroundColor"
+>
+
+  <app-expanded-chart-title
+    [titleText]="title"
+    [textColor]="textColor"
+    [tooltipText]="tooltipText"
+    [tooltipColor]="textColor"
+  ></app-expanded-chart-title>
+
+  <div class="content">
+    <div class="outside-money-chart">
+      <app-outside-spending-bar 
+        [support]="support"
+        [oppose]="oppose"
+        [backgroundColor]="backgroundColor"
+        [textColor]="textColor"       
+      ></app-outside-spending-bar>
+    </div>
+
+    <div class="expenditures-panel" [style.color]="textColor">
+      <div class="expenditures">
+        <div class="label">Total Expenditures</div>
+        <div class="amount">{{formattedCurrency(totalExpenditures)}}</div>
+      </div>
+    </div>
+  </div>
+
+</div>

--- a/src/app/candidate-quick-view/expanded-outside-money/expanded-outside-money.component.scss
+++ b/src/app/candidate-quick-view/expanded-outside-money/expanded-outside-money.component.scss
@@ -1,0 +1,47 @@
+.outside-money-container {
+  display: flex;
+  flex-direction: column;
+}
+
+.content {
+  display: flex;
+  flex-direction: row;
+  flex-flow: wrap;
+  justify-content: center;
+  padding-bottom: 5px;
+}
+
+.outside-money-chart {
+  flex: 1 1 75%;
+  min-width: 40%;
+  max-width: 100%;
+
+  box-shadow: 1px 0 grey;
+  z-index: 2;
+}
+
+.expenditures-panel {
+  flex: 1 1 25%;
+
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  .expenditures {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+
+    padding: .5em 1em 1em 1em;
+
+    .label {
+      font-size: 12px;
+      padding-bottom: .6em;
+    }
+    .amount {
+      font-size: 18px;
+      font-weight: bold;
+    }
+  }
+
+}

--- a/src/app/candidate-quick-view/expanded-outside-money/expanded-outside-money.component.stories.ts
+++ b/src/app/candidate-quick-view/expanded-outside-money/expanded-outside-money.component.stories.ts
@@ -1,0 +1,47 @@
+import { Meta, Story } from '@storybook/angular/types-6-0';
+import { moduleMetadata } from '@storybook/angular';
+import { MatTooltipModule } from '@angular/material/tooltip';
+
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
+import { NgxEchartsModule } from 'ngx-echarts';
+
+import { ExpandedOutsideMoneyComponent } from './expanded-outside-money.component';
+
+import { ExpandedChartTitleComponent } from '../expanded-chart-title/expanded-chart-title.component';
+import { OutsideSpendingBarComponent } from '../../vv-charts/outside-spending-bar/outside-spending-bar.component';
+
+
+export default {
+  title: 'Expanded/Outside Money',
+  component: ExpandedOutsideMoneyComponent,
+  decorators: [
+    moduleMetadata({
+      declarations: [
+        OutsideSpendingBarComponent,
+        ExpandedChartTitleComponent,
+      ],
+      imports: [        
+        BrowserAnimationsModule,
+        FontAwesomeModule,
+        MatTooltipModule,
+        NgxEchartsModule.forRoot({
+          echarts: () => import('echarts'),
+        }),
+      ],
+      providers: [],
+    }),
+  ], 
+  argTypes: {  },
+} as Meta;
+
+const Template: Story<ExpandedOutsideMoneyComponent> = (args: ExpandedOutsideMoneyComponent) => ({
+  props: args,
+});
+
+export const Default = Template.bind({});
+Default.args = {
+  support: 200000,
+  oppose: 5000,
+  totalExpenditures: 150000,
+};

--- a/src/app/candidate-quick-view/expanded-outside-money/expanded-outside-money.component.ts
+++ b/src/app/candidate-quick-view/expanded-outside-money/expanded-outside-money.component.ts
@@ -1,0 +1,29 @@
+import { Component, OnInit, Input, } from '@angular/core';
+
+import { faQuestionCircle } from '@fortawesome/free-solid-svg-icons';
+
+import { getCompactFormattedCurrency } from '../../shared/number-formatter'
+
+@Component({
+  selector: 'app-expanded-outside-money',
+  templateUrl: './expanded-outside-money.component.html',
+  styleUrls: ['./expanded-outside-money.component.scss']
+})
+export class ExpandedOutsideMoneyComponent implements OnInit {
+  @Input() support: number;
+  @Input() oppose: number;
+  @Input() totalExpenditures: number;
+
+  faQuestionCircle = faQuestionCircle;
+  title = 'Outside Money';
+  tooltipText = 'Amount of money raised and spent by independent expenditure committees spent in support or opposition of a candidate but not contributed directly to their campaign.';
+  textColor = 'white';
+  backgroundColor = '#2c2c2c';
+
+  formattedCurrency = getCompactFormattedCurrency;
+
+  constructor() { }
+
+  ngOnInit(): void {  }
+
+}


### PR DESCRIPTION

Typical width
![chrome_2021-07-05_16-58-55](https://user-images.githubusercontent.com/1051611/124525034-6e565180-ddb2-11eb-898c-5b5cc47f88bb.png)

Medium width
![chrome_2021-07-05_16-59-10](https://user-images.githubusercontent.com/1051611/124525037-71e9d880-ddb2-11eb-8457-f1dc36429855.png)

Narrow width
![chrome_2021-07-05_16-59-31](https://user-images.githubusercontent.com/1051611/124525064-8ded7a00-ddb2-11eb-8187-d3fe93dbebdd.png)

With tooltip text showing
![chrome_2021-07-05_16-59-48](https://user-images.githubusercontent.com/1051611/124525083-a9588500-ddb2-11eb-8d0b-6b9fb8f02727.png)

With bar tooltip showing
![chrome_2021-07-05_17-03-02](https://user-images.githubusercontent.com/1051611/124525125-de64d780-ddb2-11eb-897f-cf2300d9034f.png)

