### PR TITLE
Outside money chart

### DIFF
--- a/src/app/candidate-details/candidate-details.module.ts
+++ b/src/app/candidate-details/candidate-details.module.ts
@@ -20,6 +20,10 @@ import { DetailsTotalSpentComponent } from './details-total-spent/details-total-
 import { DetailsRaisedSpentSummaryComponent } from './details-raised-spent-summary/details-raised-spent-summary.component';
 import { DetailsTabRaisedVSpentComponent } from './details-tab-raised-v-spent/details-tab-raised-v-spent.component';
 import { DetailsContainerOutsideMoneyComponent } from './details-container-outside-money/details-container-outside-money.component';
+
+import { DetailsTabTitleComponent } from './details-tab-title/details-tab-title.component';
+import { DetailsTabRaisedByIndustryComponent } from './details-tab-raised-by-industry/details-tab-raised-by-industry.component';
+import { DetailsTabRaisedByLocationComponent } from './details-tab-raised-by-location/details-tab-raised-by-location.component';
 import { DetailsTabOutsideMoneyComponent } from './details-tab-outside-money/details-tab-outside-money.component';
 
 @NgModule({
@@ -32,6 +36,9 @@ import { DetailsTabOutsideMoneyComponent } from './details-tab-outside-money/det
     DetailsRaisedSpentSummaryComponent,
     DetailsTabRaisedVSpentComponent,
     DetailsContainerOutsideMoneyComponent,
+    DetailsTabTitleComponent,
+    DetailsTabRaisedByIndustryComponent,
+    DetailsTabRaisedByLocationComponent,
     DetailsTabOutsideMoneyComponent,
   ],
   imports: [
@@ -48,11 +55,15 @@ import { DetailsTabOutsideMoneyComponent } from './details-tab-outside-money/det
   exports: [
     CandidateDetailsHeaderComponent,
     TopCategoriesTableComponent,
+    DetailsRaisedByIndustryComponent,
     DetailsTotalRaisedComponent,
     DetailsTotalSpentComponent,
     DetailsRaisedSpentSummaryComponent,
     DetailsTabRaisedVSpentComponent,
     DetailsContainerOutsideMoneyComponent,
+    DetailsTabTitleComponent,
+    DetailsTabRaisedByIndustryComponent,
+    DetailsTabRaisedByLocationComponent,
     DetailsTabOutsideMoneyComponent,
   ],
 })

--- a/src/app/candidate-details/candidate-details.module.ts
+++ b/src/app/candidate-details/candidate-details.module.ts
@@ -19,6 +19,7 @@ import { DetailsTotalRaisedComponent } from './details-total-raised/details-tota
 import { DetailsTotalSpentComponent } from './details-total-spent/details-total-spent.component';
 import { DetailsRaisedSpentSummaryComponent } from './details-raised-spent-summary/details-raised-spent-summary.component';
 import { DetailsTabRaisedVSpentComponent } from './details-tab-raised-v-spent/details-tab-raised-v-spent.component';
+import { DetailsContainerOutsideMoneyComponent } from './details-container-outside-money/details-container-outside-money.component';
 
 @NgModule({
   declarations: [
@@ -29,6 +30,7 @@ import { DetailsTabRaisedVSpentComponent } from './details-tab-raised-v-spent/de
     DetailsTotalSpentComponent,
     DetailsRaisedSpentSummaryComponent,
     DetailsTabRaisedVSpentComponent,
+    DetailsContainerOutsideMoneyComponent,
   ],
   imports: [
     CommonModule,
@@ -48,6 +50,7 @@ import { DetailsTabRaisedVSpentComponent } from './details-tab-raised-v-spent/de
     DetailsTotalSpentComponent,
     DetailsRaisedSpentSummaryComponent,
     DetailsTabRaisedVSpentComponent,
+    DetailsContainerOutsideMoneyComponent,
   ],
 })
 export class CandidateDetailsModule { }

--- a/src/app/candidate-details/candidate-details.module.ts
+++ b/src/app/candidate-details/candidate-details.module.ts
@@ -20,6 +20,7 @@ import { DetailsTotalSpentComponent } from './details-total-spent/details-total-
 import { DetailsRaisedSpentSummaryComponent } from './details-raised-spent-summary/details-raised-spent-summary.component';
 import { DetailsTabRaisedVSpentComponent } from './details-tab-raised-v-spent/details-tab-raised-v-spent.component';
 import { DetailsContainerOutsideMoneyComponent } from './details-container-outside-money/details-container-outside-money.component';
+import { DetailsTabOutsideMoneyComponent } from './details-tab-outside-money/details-tab-outside-money.component';
 
 @NgModule({
   declarations: [
@@ -31,6 +32,7 @@ import { DetailsContainerOutsideMoneyComponent } from './details-container-outsi
     DetailsRaisedSpentSummaryComponent,
     DetailsTabRaisedVSpentComponent,
     DetailsContainerOutsideMoneyComponent,
+    DetailsTabOutsideMoneyComponent,
   ],
   imports: [
     CommonModule,
@@ -51,6 +53,7 @@ import { DetailsContainerOutsideMoneyComponent } from './details-container-outsi
     DetailsRaisedSpentSummaryComponent,
     DetailsTabRaisedVSpentComponent,
     DetailsContainerOutsideMoneyComponent,
+    DetailsTabOutsideMoneyComponent,
   ],
 })
 export class CandidateDetailsModule { }

--- a/src/app/candidate-details/details-container-outside-money/details-container-outside-money.component.html
+++ b/src/app/candidate-details/details-container-outside-money/details-container-outside-money.component.html
@@ -1,0 +1,37 @@
+
+<div class="outside-money-container">
+  
+  <app-outside-money-stacked-bar
+    [opposedCommittees]="oppositionCommittees"
+    [supportCommittees]="supportCommittees"
+    [committeeHighlighted]="hoveredCommittee"
+    (committeeHighlightedChange)="committeeHoveredOver($event)"
+  ></app-outside-money-stacked-bar>
+  
+  <div class="committee-tables">
+    <div class="opposition-panel">
+      <div class="heading">
+        <fa-icon [icon]="faCircle" [icon]="faCircle" [style.color]="oppositionColor" ></fa-icon>
+        {{oppositionExpenditures.title}}
+      </div>
+      <app-top-categories-table class="opposition-table"
+        [categories]='oppositionCommittees'
+        [categoryHighlighted]="hoveredCommittee"
+        (categoryHighlightedChange)="committeeHoveredOver($event)"
+      ></app-top-categories-table>      
+    </div>
+
+    <div class="support-panel">
+      <div class="heading">
+        <fa-icon [icon]="faCircle" [style.color]="supportColor" ></fa-icon>
+        {{supportExpenditures.title}}
+      </div>
+      <app-top-categories-table  class="support-table"
+        [categories]='supportCommittees'
+        [categoryHighlighted]="hoveredCommittee"
+        (categoryHighlightedChange)="committeeHoveredOver($event)"
+      ></app-top-categories-table>
+    </div>
+  </div>
+  
+</div>

--- a/src/app/candidate-details/details-container-outside-money/details-container-outside-money.component.scss
+++ b/src/app/candidate-details/details-container-outside-money/details-container-outside-money.component.scss
@@ -1,0 +1,36 @@
+
+.outside-money-container {
+  width: 100%;
+
+  display: flex;
+  flex-direction: column;
+}
+
+.committee-tables {
+  width: 100%;
+  display: flex;
+  flex-direction: row;
+}
+
+.opposition-panel, .support-panel {
+  flex: 1 1 50%;
+  padding-left: 5%;
+  padding-right: 5%;
+
+
+  display: flex;
+  flex-direction: column;
+}
+
+.heading {
+  width: 100%;
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+}
+
+fa-icon {
+  font-size: 10px;
+  margin-right: 10px;
+}

--- a/src/app/candidate-details/details-container-outside-money/details-container-outside-money.component.stories.ts
+++ b/src/app/candidate-details/details-container-outside-money/details-container-outside-money.component.stories.ts
@@ -1,0 +1,34 @@
+import { Meta, Story } from '@storybook/angular/types-6-0';
+import { moduleMetadata } from '@storybook/angular';
+
+import { CandidateDetailsModule } from '../candidate-details.module';
+
+import { DetailsContainerOutsideMoneyComponent } from './details-container-outside-money.component';
+
+import * as OutsideMoneyStackedBarStories from '../../vv-charts/outside-money-stacked-bar/outside-money-stacked-bar.component.stories'
+
+export default {
+  title: 'Candidate Details/Container/Outside Money',
+  component: DetailsContainerOutsideMoneyComponent,
+  decorators: [
+    moduleMetadata({
+      declarations: [],
+      imports: [
+        CandidateDetailsModule,
+      ],
+      providers: [],
+    }),
+  ], 
+  argTypes: { },
+} as Meta;
+
+const Template: Story<DetailsContainerOutsideMoneyComponent> = (args: DetailsContainerOutsideMoneyComponent) => ({
+  props: args,
+});
+
+
+export const Default = Template.bind({});
+Default.args = {
+  oppositionExpendituresCategories: OutsideMoneyStackedBarStories.Default.args.opposedCommittees,
+  supportExpendituresCategories: OutsideMoneyStackedBarStories.Default.args.supportCommittees,
+};

--- a/src/app/candidate-details/details-container-outside-money/details-container-outside-money.component.ts
+++ b/src/app/candidate-details/details-container-outside-money/details-container-outside-money.component.ts
@@ -1,0 +1,54 @@
+import { Component, Input, OnChanges, } from '@angular/core';
+
+import { faCircle } from '@fortawesome/free-solid-svg-icons';
+
+@Component({
+  selector: 'app-details-container-outside-money',
+  templateUrl: './details-container-outside-money.component.html',
+  styleUrls: ['./details-container-outside-money.component.scss']
+})
+export class DetailsContainerOutsideMoneyComponent implements OnChanges {
+  @Input() oppositionExpendituresCategories;
+  @Input() supportExpendituresCategories;
+
+  hoveredCommittee: string = null;
+  oppositionCommittees;
+  supportCommittees;
+
+  oppositionColor = '#6964AD';
+  supportColor = '#3392FF';
+
+  oppositionExpenditures = {
+    title: 'Expenditures in Opposition',
+    categories: [],
+  };
+
+  supportExpenditures = {
+    title: 'Expenditures in Support',
+    categories: [],
+  };
+  
+  faCircle = faCircle;
+
+  constructor() { }
+
+  ngOnChanges(): void {
+    this.oppositionCommittees = 
+      this.oppositionExpendituresCategories.map( committee => ({
+        ...committee,
+        color: this.oppositionColor,
+      }));
+
+    this.supportCommittees = 
+      this.supportExpendituresCategories.map( committee => ({
+        ...committee,
+        color: this.supportColor,
+      }));
+
+  }
+
+  committeeHoveredOver(committee){
+    this.hoveredCommittee = committee;
+  }
+  
+}

--- a/src/app/candidate-details/details-raised-by-industry/details-raised-by-industry.component.stories.ts
+++ b/src/app/candidate-details/details-raised-by-industry/details-raised-by-industry.component.stories.ts
@@ -8,7 +8,7 @@ import { DetailsRaisedByIndustryComponent } from './details-raised-by-industry.c
 import * as RaisedByIndustryBarStories from '../../vv-charts/raised-by-industry-bar/raised-by-industry-bar.component.stories';
 
 export default {
-  title: 'Candidate Details/Raised By Industry',
+  title: 'Candidate Details/Container/Raised By Industry',
   component: DetailsRaisedByIndustryComponent,
   decorators: [
     moduleMetadata({

--- a/src/app/candidate-details/details-tab-outside-money/details-tab-outside-money.component.html
+++ b/src/app/candidate-details/details-tab-outside-money/details-tab-outside-money.component.html
@@ -1,0 +1,15 @@
+
+<div class="tab-outside-money">
+
+  <app-details-tab-title
+    [smallTitleText]="title.top"
+    [largeTitleText]="title.bottom"
+    [tooltipText]="title.tooltipText"
+  ></app-details-tab-title>
+
+  <app-details-container-outside-money
+    [oppositionExpendituresCategories]="oppositionExpendituresCategories"
+    [supportExpendituresCategories]="supportExpendituresCategories"
+  ></app-details-container-outside-money>
+
+</div>

--- a/src/app/candidate-details/details-tab-outside-money/details-tab-outside-money.component.scss
+++ b/src/app/candidate-details/details-tab-outside-money/details-tab-outside-money.component.scss
@@ -1,0 +1,5 @@
+
+.tab-outside-money {
+  display: flex;
+  flex-direction: column;
+}

--- a/src/app/candidate-details/details-tab-outside-money/details-tab-outside-money.component.stories.ts
+++ b/src/app/candidate-details/details-tab-outside-money/details-tab-outside-money.component.stories.ts
@@ -1,0 +1,34 @@
+import { Meta, Story } from '@storybook/angular/types-6-0';
+import { moduleMetadata } from '@storybook/angular';
+
+import { CandidateDetailsModule } from '../candidate-details.module';
+
+import { DetailsOutsideMoneyComponent } from './details-tab-outside-money.component';
+
+import * as DetailsContainerOutsideMoneyStories  from '../details-container-outside-money/details-container-outside-money.component.stories';
+
+export default {
+  title: 'Candidate Details/Tab/Outside Money',
+  component: DetailsOutsideMoneyComponent,
+  decorators: [
+    moduleMetadata({
+      declarations: [],
+      imports: [
+        CandidateDetailsModule,
+      ],
+      providers: [],
+    }),
+  ], 
+  argTypes: { },
+} as Meta;
+
+const Template: Story<DetailsOutsideMoneyComponent> = (args: DetailsOutsideMoneyComponent) => ({
+  props: args,
+});
+
+
+export const Default = Template.bind({});
+Default.args = {
+  oppositionExpendituresCategories: DetailsContainerOutsideMoneyStories.Default.args.oppositionExpendituresCategories,
+  supportExpendituresCategories: DetailsContainerOutsideMoneyStories.Default.args.supportExpendituresCategories,
+};

--- a/src/app/candidate-details/details-tab-outside-money/details-tab-outside-money.component.stories.ts
+++ b/src/app/candidate-details/details-tab-outside-money/details-tab-outside-money.component.stories.ts
@@ -3,13 +3,13 @@ import { moduleMetadata } from '@storybook/angular';
 
 import { CandidateDetailsModule } from '../candidate-details.module';
 
-import { DetailsOutsideMoneyComponent } from './details-tab-outside-money.component';
+import { DetailsTabOutsideMoneyComponent } from './details-tab-outside-money.component';
 
 import * as DetailsContainerOutsideMoneyStories  from '../details-container-outside-money/details-container-outside-money.component.stories';
 
 export default {
   title: 'Candidate Details/Tab/Outside Money',
-  component: DetailsOutsideMoneyComponent,
+  component: DetailsTabOutsideMoneyComponent,
   decorators: [
     moduleMetadata({
       declarations: [],
@@ -22,7 +22,7 @@ export default {
   argTypes: { },
 } as Meta;
 
-const Template: Story<DetailsOutsideMoneyComponent> = (args: DetailsOutsideMoneyComponent) => ({
+const Template: Story<DetailsTabOutsideMoneyComponent> = (args: DetailsTabOutsideMoneyComponent) => ({
   props: args,
 });
 

--- a/src/app/candidate-details/details-tab-outside-money/details-tab-outside-money.component.ts
+++ b/src/app/candidate-details/details-tab-outside-money/details-tab-outside-money.component.ts
@@ -5,7 +5,7 @@ import { Component, Input, OnChanges, } from '@angular/core';
   templateUrl: './details-tab-outside-money.component.html',
   styleUrls: ['./details-tab-outside-money.component.scss']
 })
-export class DetailsOutsideMoneyComponent implements OnChanges {
+export class DetailsTabOutsideMoneyComponent implements OnChanges {
   @Input() oppositionExpendituresCategories;
   @Input() supportExpendituresCategories;
  

--- a/src/app/candidate-details/details-tab-outside-money/details-tab-outside-money.component.ts
+++ b/src/app/candidate-details/details-tab-outside-money/details-tab-outside-money.component.ts
@@ -1,0 +1,23 @@
+import { Component, Input, OnChanges, } from '@angular/core';
+
+@Component({
+  selector: 'app-details-tab-outside-money',
+  templateUrl: './details-tab-outside-money.component.html',
+  styleUrls: ['./details-tab-outside-money.component.scss']
+})
+export class DetailsOutsideMoneyComponent implements OnChanges {
+  @Input() oppositionExpendituresCategories;
+  @Input() supportExpendituresCategories;
+ 
+  title = {
+    top: 'Independent Expenditures',
+    bottom: 'By Outside Money',
+    tooltipText: 'Placeholder tooltip text for Amount Raised by Outside Money!',
+  };
+
+  constructor() { }
+
+  ngOnChanges(): void {
+  }
+
+}

--- a/src/app/candidate-details/details-total-raised/details-total-raised.component.stories.ts
+++ b/src/app/candidate-details/details-total-raised/details-total-raised.component.stories.ts
@@ -9,7 +9,7 @@ import { DetailsTotalRaisedComponent } from './details-total-raised.component';
 import * as TotalRaisedBarStories from '../../vv-charts/total-raised-bar/total-raised-bar.component.stories';
 
 export default {
-  title: 'Candidate Details/Total Raised',
+  title: 'Candidate Details/Container/Total Raised',
   component: DetailsTotalRaisedComponent,
   decorators: [
     moduleMetadata({

--- a/src/app/candidate-details/details-total-spent/details-total-spent.component.stories.ts
+++ b/src/app/candidate-details/details-total-spent/details-total-spent.component.stories.ts
@@ -10,7 +10,7 @@ import * as TopCategoriesTableStories from '../top-categories-table/top-categori
 import * as TotalSpentDonutStories from '../../vv-charts/total-spent-donut/total-spent-donut.component.stories';
 
 export default {
-  title: 'Candidate Details/Total Spent',
+  title: 'Candidate Details/Container/Total Spent',
   component: DetailsTotalSpentComponent,
   decorators: [
     moduleMetadata({

--- a/src/app/candidate-details/top-categories-table/top-categories-table.component.html
+++ b/src/app/candidate-details/top-categories-table/top-categories-table.component.html
@@ -18,7 +18,7 @@
     <tr mat-row 
       *matRowDef="let row; columns: displayedColumns"
       (mouseover)="hoveredRow(row)"
-      (mouseout)="hoveredRow({id: null})"
+      (mouseout)="hoveredRow({id: '-1'})"
       [class.highlighted]="row.id === categoryHighlighted"
     ></tr>
   </table>

--- a/src/app/candidate-details/top-categories-table/top-categories-table.component.ts
+++ b/src/app/candidate-details/top-categories-table/top-categories-table.component.ts
@@ -20,9 +20,7 @@ export class TopCategoriesTableComponent implements OnChanges {
   @Input() categories: Category[];
   @Input() categoryHighlighted: string;
   @Output() categoryHighlightedChange = new EventEmitter<string>();
-  
-  @Input() useHSLColors?: boolean = false;
-  
+    
   dataSource;
   displayedColumns: string[] = ['name', 'value', 'percent'];
 

--- a/src/app/vv-charts/outside-money-stacked-bar/outside-money-stacked-bar.component.html
+++ b/src/app/vv-charts/outside-money-stacked-bar/outside-money-stacked-bar.component.html
@@ -1,0 +1,9 @@
+
+<div class="outside-money-stacked-bar-chart" echarts 
+  [options]="chartOption"
+  [merge]="mergeOption"
+
+  (chartInit)="onChartInit($event)"
+  (chartMouseOver)="hoveredBar($event)"
+  (chartMouseOut)="hoveredBar({ seriesId: '-1' })"
+></div>  

--- a/src/app/vv-charts/outside-money-stacked-bar/outside-money-stacked-bar.component.scss
+++ b/src/app/vv-charts/outside-money-stacked-bar/outside-money-stacked-bar.component.scss
@@ -1,0 +1,10 @@
+
+.outside-money-stacked-bar-chart {
+  height: 300px;
+  min-height: 150px;
+  width: 100%;
+  min-width: 150px;
+
+  display: flex;
+  justify-content: center;
+}

--- a/src/app/vv-charts/outside-money-stacked-bar/outside-money-stacked-bar.component.stories.ts
+++ b/src/app/vv-charts/outside-money-stacked-bar/outside-money-stacked-bar.component.stories.ts
@@ -1,0 +1,94 @@
+import { Meta, Story } from '@storybook/angular/types-6-0';
+import { moduleMetadata } from '@storybook/angular';
+
+import { OutsideMoneyStackedBarComponent } from './outside-money-stacked-bar.component';
+
+import { VvChartsModule } from '../vv-charts.module';
+
+export default {
+  title: 'ECharts/Outside Money Stacked Bar',
+  component: OutsideMoneyStackedBarComponent,
+  decorators: [
+    moduleMetadata({
+      declarations: [],
+      imports: [
+        VvChartsModule,
+      ],
+      providers: [],
+    }),
+  ], 
+  argTypes: {
+  },
+} as Meta;
+
+const Template: Story<OutsideMoneyStackedBarComponent> = (args: OutsideMoneyStackedBarComponent) => ({
+  props: args,
+});
+
+export const Default = Template.bind({});
+Default.args = {
+  opposedCommittees: [
+    {
+      id: '0',
+      name: 'Expenditure Committee A',
+      value: 22321,
+      percent: 20.8,
+    },
+    {
+      id: '1',
+      name: 'Expenditure Committee B',
+      value: 11987,
+      percent: 17,
+    },
+    {
+      id: '2',
+      name: 'Expenditure Committee C',
+      value: 10345,
+      percent: 8,
+    },
+    {
+      id: '3',
+      name: 'Expenditure Committee D',
+      value: 7876,
+      percent: 3,
+    },
+    {
+      id: '4',
+      name: 'Other',
+      value: 3654,
+      percent: 2,
+    },
+  ],
+  supportCommittees: [
+    {
+      id: '5',
+      name: 'Support Committee E',
+      value: 26321,
+      percent: 20.8,
+    },
+    {
+      id: '6',
+      name: 'Support Committee F',
+      value: 19876,
+      percent: 17,
+    },
+    {
+      id: '7',
+      name: 'Support Committee G',
+      value: 12345,
+      percent: 8,
+    },
+    {
+      id: '8',
+      name: 'Support Committee H',
+      value: 9876,
+      percent: 3,
+    },
+    {
+      id: '9',
+      name: 'Other',
+      value: 7654,
+      percent: 2,
+    },
+  ],
+};

--- a/src/app/vv-charts/outside-money-stacked-bar/outside-money-stacked-bar.component.ts
+++ b/src/app/vv-charts/outside-money-stacked-bar/outside-money-stacked-bar.component.ts
@@ -1,0 +1,143 @@
+import { Component, EventEmitter, Input, OnChanges, Output } from '@angular/core';
+
+import { EChartsOption, ECharts, BarSeriesOption } from 'echarts';
+
+import { getCompactFormattedCurrency } from '../../shared/number-formatter'
+
+@Component({
+  selector: 'app-outside-money-stacked-bar',
+  templateUrl: './outside-money-stacked-bar.component.html',
+  styleUrls: ['./outside-money-stacked-bar.component.scss']
+})
+export class OutsideMoneyStackedBarComponent implements OnChanges {
+  @Input() opposedCommittees;
+  @Input() supportCommittees;
+  @Input() committeeHighlighted: string = '-1';
+  @Output() committeeHighlightedChange = new EventEmitter<string>();
+
+  defaultOpposedBarColor = 'darkRed';
+  defaultSupportBarColor = 'darkGreen';
+
+  echartsInstance: ECharts;
+  mergeOption: EChartsOption;
+
+  chartOption: EChartsOption = {
+    tooltip: {
+      show: true,
+      trigger: 'item',
+      formatter: (params) =>  
+        `${params.seriesName}: $${Math.abs(params.value).toLocaleString()}`,
+    },
+    xAxis: {
+      type: 'value',
+      axisLabel: {
+        formatter: (value: number) => 
+          getCompactFormattedCurrency(Math.abs(value)),
+      },
+    },
+    yAxis: {
+      type: 'category',
+      data: [''],
+      axisTick: {
+        show: false,
+      },
+    },
+  }
+
+  constructor() { }
+
+  ngOnChanges(): void {
+    this.setChartMergeOption();
+    this.updateChartHighlight();
+  }
+
+  onChartInit(ec: ECharts): void {
+    this.echartsInstance = ec;
+  }
+
+  updateChartHighlight() {
+    if (this.echartsInstance) {
+      this.echartsInstance.dispatchAction({ type: 'downplay' });
+      this.echartsInstance.dispatchAction({ 
+        type: 'highlight', 
+        seriesId: this.committeeHighlighted,
+      });
+    }
+  }
+
+  hoveredBar = (event: object) => {
+    this.committeeHighlightedChange.emit(event['seriesId']+'');
+  }
+
+
+  getSeriesOptions(committees, defaultColor: string, direction: 'left' | 'right'): BarSeriesOption[]  {
+    const directionMultiplier = (direction === 'left') ? -1 : 1; 
+
+    const seriesTemplate = {
+      type: 'bar',
+      stack: 'outside-money',
+      emphasis: {
+        focus: 'series',
+      },
+      blur: {
+        itemStyle: { opacity: .5, },
+      },
+    } as const;
+
+    return committees.map((data) => ({
+      ...seriesTemplate,
+      id: data.id,
+      name: data.name,
+      itemStyle: { color: (data.color) ? data.color : defaultColor, },
+      data: [ directionMultiplier * data.value],
+    }));
+  }
+  
+  getChartBalancer(sum1: number, sum2: number): BarSeriesOption {
+    const maxBarAmount = Math.max(sum1, sum2);
+
+    return {
+      type: 'bar',
+      stack: 'hidden',
+      name: 'chart-balancer',
+      barGap: '-100%',
+      z: -10,
+      itemStyle: { opacity: 0, color: 'grey'},
+      silent: true,
+      data: [-maxBarAmount, maxBarAmount],
+    };
+  }
+
+  setChartMergeOption(): void {
+
+    const opposedSeries: BarSeriesOption[] =
+      this.getSeriesOptions(this.opposedCommittees, this.defaultOpposedBarColor, 'left');
+    const supportSeries: BarSeriesOption[] = 
+      this.getSeriesOptions(this.supportCommittees, this.defaultSupportBarColor, 'right');
+
+    const seriesSumReducer = (accumulator, currentValue) => accumulator + currentValue.value;
+    const opposedSum = this.opposedCommittees.reduce(seriesSumReducer, 0);
+    const supportSum = this.supportCommittees.reduce(seriesSumReducer, 0);
+
+    opposedSeries[opposedSeries.length-1]['label'] = {
+      show: true,
+      fontWeight: 'bold',
+      position: 'left',
+      formatter: getCompactFormattedCurrency(opposedSum),
+    };
+
+    supportSeries[supportSeries.length-1]['label'] = {
+      show: true,
+      fontWeight: 'bold',
+      position: 'right',
+      formatter: getCompactFormattedCurrency(supportSum),
+    };
+
+    const balancerSeries = this.getChartBalancer(opposedSum, supportSum);
+   
+    this.mergeOption = {
+      series: [...opposedSeries, ...supportSeries, balancerSeries],
+    };
+  }
+
+}

--- a/src/app/vv-charts/vv-charts.module.ts
+++ b/src/app/vv-charts/vv-charts.module.ts
@@ -20,6 +20,7 @@ import { OutsideSpendingBarComponent } from './outside-spending-bar/outside-spen
 import { TotalRaisedBarComponent } from './total-raised-bar/total-raised-bar.component';
 import { RaisedVsSpentBarComponent } from './raised-vs-spent-bar/raised-vs-spent-bar.component';
 import { RaisedInVsOutDonutComponent } from './raised-in-vs-out-donut/raised-in-vs-out-donut.component';
+import { OutsideMoneyStackedBarComponent } from './outside-money-stacked-bar/outside-money-stacked-bar.component';
 
 @NgModule({
   declarations: [
@@ -36,6 +37,7 @@ import { RaisedInVsOutDonutComponent } from './raised-in-vs-out-donut/raised-in-
     TotalRaisedBarComponent,
     RaisedVsSpentBarComponent,
     RaisedInVsOutDonutComponent,
+    OutsideMoneyStackedBarComponent,
   ],
   imports: [
     CommonModule,
@@ -61,6 +63,7 @@ import { RaisedInVsOutDonutComponent } from './raised-in-vs-out-donut/raised-in-
     TotalRaisedBarComponent,
     RaisedVsSpentBarComponent,
     RaisedInVsOutDonutComponent,
+    OutsideMoneyStackedBarComponent,
   ],
   providers: [RoundCurrencyPipe]
 })


### PR DESCRIPTION

 The title of the Outside Money tab. has been changed from 'Amount Raised' to 'Independent Expenditures'
![chrome_2021-07-17_14-30-15](https://user-images.githubusercontent.com/1051611/126049767-cdf3a354-7795-43f8-a13a-cf5202a146ba.png)


The Outside Spending chart container links the highlighting of the chart and the tables together. 
![2021-07-17_14-28-00](https://user-images.githubusercontent.com/1051611/126049733-0c465716-0711-451d-923e-82e6b58e8a31.gif)


This chart will replace the other Outside Money chart in the detail view. This chart supports highlighting individual bar elements and the max range for each side will now be then same for the opposed and support bars.

![chrome_2021-07-17_14-22-29](https://user-images.githubusercontent.com/1051611/126049646-46d010db-76c5-44fb-b928-7f2b9e43821f.png)
