### PR TITLE
Fix for RaisedInVsOutDonut when input is null.

### DIFF
--- a/src/app/vv-charts/raised-in-vs-out-donut/raised-in-vs-out-donut.component.ts
+++ b/src/app/vv-charts/raised-in-vs-out-donut/raised-in-vs-out-donut.component.ts
@@ -66,14 +66,14 @@ export class RaisedInVsOutDonutComponent implements OnChanges {
         data: [
           {
             name: 'Inside',
-            value: this.inside,
+            value: this.inside ? this.inside : 0,
             color: '#3392ff',
             itemStyle: { color: '#3392ff' },
             label: { position: 'center', }
           },
           {
             name: 'Outside',
-            value: this.outside,
+            value: this.outside ? this.outside : 0,
             color: '#bfd63b',
             itemStyle: { color: '#bfd63b' },
             label: { 


### PR DESCRIPTION
Before
![chrome_2022-01-05_22-30-29](https://user-images.githubusercontent.com/1051611/148339028-4044c510-2aed-4390-9822-3319d94ad7a4.png)

After
![chrome_2022-01-05_22-30-43](https://user-images.githubusercontent.com/1051611/148339042-ddaeab86-4566-422a-b3a7-2878c6819e1b.png)

