### PR TITLE
Adds npm script to run against a remote database.

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -73,7 +73,15 @@
                 }
               ]
             },
-            "development": {}
+            "development": {},
+            "db-remote": {
+              "fileReplacements": [
+                {
+                  "replace": "src/environments/environment.ts",
+                  "with": "src/environments/environment.db-remote.ts"
+                }
+              ]
+            }
           },
           "defaultConfiguration": "production"
         },
@@ -87,6 +95,9 @@
             },
             "development": {
               "browserTarget": "sdvv-frontend:build:development"
+            },
+            "db-remote": {
+              "browserTarget": "sdvv-frontend:build:db-remote"
             }
           },
           "defaultConfiguration": "development"

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "scripts": {
     "ng": "ng",
     "start:lib": "ng build lib-ui-charts --watch",
+    "start:db:remote": "ng serve --configuration=db-remote",
     "start": "ng serve",
     "build:lib": "ng build lib-ui-charts",
     "build:app": "ng build --configuration production",

--- a/src/environments/environment.db-remote.ts
+++ b/src/environments/environment.db-remote.ts
@@ -1,0 +1,6 @@
+
+export const environment = {
+  production: false,
+  apiUrl: 'https://opensandiego-voters-voice.herokuapp.com'
+};
+


### PR DESCRIPTION
Developer can work on app without running the database locally.

To do so use the npm script: **start:db:remote**

`npm run start:db:remote`