### PR TITLE
Fixes issue 373

### DIFF
--- a/src/app/details-raised-spent/components/details-total-spent/details-total-spent.component.ts
+++ b/src/app/details-raised-spent/components/details-total-spent/details-total-spent.component.ts
@@ -52,12 +52,10 @@ export class DetailsTotalSpentComponent implements OnInit {
           this.totalSpentFormatted = this.totalSpent
             .toLocaleString('en', { style: 'currency', currency: 'USD', maximumFractionDigits: 0});
 
-          const filteredGroups = response.spentGroup.filter( group => group.spending_code );
-
-          this.categoriesCombined = filteredGroups.map((group, i) => ({
+          this.categoriesCombined = response.spentGroup.map((group, i) => ({
             id: i.toString(),
-            // name: group.spending_code ? group.spending_code : 'null',
-            name: group.spending_code ? this.getSpendingCodeDescription(group.spending_code) : 'null',
+            code: group.spending_code,
+            name: group.spending_code ? this.getSpendingCodeDescription(group.spending_code) : 'not categorized',
             value: parseInt(group.sum),
             percent: parseFloat(group.average),
             color: i < this.colors.length ? this.colors[i] : 'red',

--- a/src/app/vv-charts/total-spent-donut/total-spent-donut.component.ts
+++ b/src/app/vv-charts/total-spent-donut/total-spent-donut.component.ts
@@ -113,7 +113,9 @@ export class TotalSpentDonutComponent implements OnChanges {
   }
   
   getFormattedTooltip(params) {
-    return `<div style="font-size: 1em; margin-bottom: 8px">${params.data.name}</div>` 
+    const label = params.data.code ? params.data.code : params.data.name;
+
+    return `<div style="font-size: 1em; margin-bottom: 8px">${label}</div>` 
          + `<div style="font-size: 1.5em;">${getCompactFormattedCurrency(params.data.value)}</div>`;
   }
 


### PR DESCRIPTION
closes #373 

Displays **not categorized** for the group of expenditures that have a blank in the **Expn_Code** field.

![chrome_2022-02-04_21-46-57](https://user-images.githubusercontent.com/1051611/152630405-d43203d0-1982-425a-91ba-84815f5480c1.png)

And
![image](https://user-images.githubusercontent.com/1051611/152630506-6d8a8a88-eef7-48d5-b8ed-276fc0a48ea1.png)

Some of the description texts did not fit well inside the donut.
Below is the before image:
![image](https://user-images.githubusercontent.com/1051611/152630554-c531d446-8734-4862-add1-f732cce71480.png)

Now shows expense code inside donut instead of the description. 
![image](https://user-images.githubusercontent.com/1051611/152630529-b7ec7790-bfec-4011-b7f8-4259250e5fa3.png)
