### PR TITLE
Fixes number rounding with suffixes.

### DIFF
--- a/src/app/public/pipes/round-currency-display.pipe.ts
+++ b/src/app/public/pipes/round-currency-display.pipe.ts
@@ -6,14 +6,14 @@ import { Pipe, PipeTransform } from "@angular/core";
 export class RoundCurrencyDisplayPipe implements PipeTransform {
   transform(input: any, args?: any): any {
     var exp,
-      oneMillion = 1000000,
+      limit = 10000,
       suffixes = ["k", "M", "G", "T", "P", "E"];
 
     if (Number.isNaN(input)) {
       return null;
     }
  
-    if (parseInt(input) < oneMillion) {
+    if (parseInt(input) < limit) {
       return Number(input).toLocaleString('en-US');
     }
 

--- a/src/app/shared/number-formatter.ts
+++ b/src/app/shared/number-formatter.ts
@@ -13,12 +13,13 @@ export function getCompactFormattedCurrency(value: number, decimalDigits?: numbe
  * Formats number as a currency and uses compact format (for example: 10K) only 
  * when value is greater than 9999.
  */
-export function getFormattedCurrency(value: number, decimalDigits?: number): string {
+export function getFormattedCurrency(value: number, maxDecimalDigits: number = 0): string {
+  const limit = 9999;
+  const isCompact = value > limit;
 
-  const notation = value > 9999 ? 'compact' : 'standard';
+  const notation = isCompact ? 'compact' : 'standard';
+  const fractionDigits = isCompact ? maxDecimalDigits : 0;
 
-  const fractionDigits = decimalDigits ? decimalDigits : 0;
-  
   // @ts-ignore:
   const formatter = Intl.NumberFormat('en', { notation, style: 'currency', currency: 'USD',  maximumFractionDigits: fractionDigits });
 


### PR DESCRIPTION
Fixed number suffix when amount was under a million.


Note the City Council amount in the Before 
Year: 2022
![image](https://user-images.githubusercontent.com/1051611/152630801-7db9a56d-0ef3-41b1-b9b0-46ea590f5e10.png)
and Year: 2020
![image](https://user-images.githubusercontent.com/1051611/152630824-ee2e6931-19de-4afd-a518-ae71e22556c3.png)

Note the City Council amount in the After
Year: 2022
![image](https://user-images.githubusercontent.com/1051611/152630847-0e7277c8-11d4-4d74-a6d3-16bf070836ce.png)
and Year: 2020
![image](https://user-images.githubusercontent.com/1051611/152630842-e82b2d74-5bfd-4846-b692-64a5e3ac0603.png)
